### PR TITLE
Fix stuck left-click when GUI is open

### DIFF
--- a/utils/player/Keybinding.js
+++ b/utils/player/Keybinding.js
@@ -45,13 +45,18 @@ class ControlSystem {
     }
 
     updateKeyState(action, isPressed) {
-        if (this.isGuiOpen()) return false;
+        const guiOpen = this.isGuiOpen();
 
         if (action === 'leftclick') {
             const attackKey = mc.options.attackKey;
-            const mouseGrabbed = net.minecraft.client.Mouse.class.getDeclaredField('field_1783');
-            mouseGrabbed.setAccessible(true);
-            mouseGrabbed.setBoolean(Client.getMinecraft().mouse, true);
+
+            if (isPressed && guiOpen) return false;
+
+            if (isPressed) {
+                const mouseGrabbed = net.minecraft.client.Mouse.class.getDeclaredField('field_1783');
+                mouseGrabbed.setAccessible(true);
+                mouseGrabbed.setBoolean(Client.getMinecraft().mouse, true);
+            }
 
             ScheduleTask(() => {
                 attackKey.setPressed(!!isPressed);
@@ -59,6 +64,8 @@ class ControlSystem {
 
             return true;
         }
+
+        if (guiOpen) return false;
 
         const options = mc.options;
         const mapping = {


### PR DESCRIPTION
### Motivation
- A recent refactor added an early GUI check in `updateKeyState` that prevented all `leftclick` updates while a non-chat GUI was open, which could leave the `attackKey` stuck pressed after `unpressKeys()`/`fullRelease()`.
- The intent is to centralize GUI checks and block new click presses while still allowing release actions to clear held inputs.

### Description
- Updated `utils/player/Keybinding.js` `updateKeyState` to compute `guiOpen` and handle the `leftclick` case before short-circuiting, so `leftclick=false` is still applied while a GUI is open.
- Added `if (isPressed && guiOpen) return false;` to block `leftclick=true` when GUI is open and preserved scheduling of `attackKey.setPressed(!!isPressed)` for all releases/presses.
- Scoped the mouse-grab reflection (`net.minecraft.client.Mouse` field write) to press-only flows to avoid unnecessary writes on release.
- Left the GUI early-return in place for non-leftclick keys so movement/action keys remain blocked while GUI is open.

### Testing
- Ran `npx prettier --check utils/player/Keybinding.js` and it passed.
- Performed a static code inspection to confirm that `leftclick=false` always schedules `attackKey.setPressed(false)`, that `leftclick=true` is blocked when GUI is open, and that mouse-grab reflection only runs for press events.
- No automated unit tests exist in-repo; change is minimal and focused to avoid regressions with existing behaviors described in the project guidelines.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b48c09514083338dde8c60da3173f9)