### PR TITLE
Add ModuleHistory tracking with overlay session snapshots

### DIFF
--- a/gui/OverlayUtils.js
+++ b/gui/OverlayUtils.js
@@ -16,7 +16,6 @@ import {
 } from './Utils';
 import { GuiState, Overlays } from './core/GuiState';
 import { ServerInfo } from '../utils/player/ServerInfo';
-import { ModuleHistory } from '../utils/ModuleHistory';
 
 const { loadSettings } = require('./GuiSave');
 
@@ -208,8 +207,6 @@ class OverlayUtils {
     }
 
     resetAll() {
-        ModuleHistory.endAllSessions('game_unload');
-
         this.ids = [];
         this.animations = {};
         this.startTimes = {};

--- a/gui/OverlayUtils.js
+++ b/gui/OverlayUtils.js
@@ -16,6 +16,7 @@ import {
 } from './Utils';
 import { GuiState, Overlays } from './core/GuiState';
 import { ServerInfo } from '../utils/player/ServerInfo';
+import { ModuleHistory } from '../utils/ModuleHistory';
 
 const { loadSettings } = require('./GuiSave');
 
@@ -207,6 +208,8 @@ class OverlayUtils {
     }
 
     resetAll() {
+        ModuleHistory.endAllSessions('game_unload');
+
         this.ids = [];
         this.animations = {};
         this.startTimes = {};
@@ -305,6 +308,26 @@ class OverlayUtils {
     incrementTrackedValue(idName, key, amount = 1) {
         const current = Number(this.getTrackedValue(idName, key, 0)) || 0;
         return this.setTrackedValue(idName, key, current + amount);
+    }
+
+    getSessionSnapshot(idName) {
+        const overlay = this.ids.find((id) => id.name === idName);
+        const sections = (overlay?.sections || []).map((section) => {
+            const data = {};
+            Object.entries(section.data || {}).forEach(([key, value]) => {
+                data[key] = typeof value === 'function' ? value() : value;
+            });
+
+            return {
+                title: section.title,
+                data,
+            };
+        });
+
+        return {
+            trackedValues: { ...this.resolveTrackedValues(idName) },
+            sections,
+        };
     }
 
     getSessionElapsedMs(idName) {

--- a/utils/Config.js
+++ b/utils/Config.js
@@ -103,6 +103,7 @@ const manifest = {
         'OverlayPositions/music_overlay.json': {},
         'webhook.json': {},
         'miningstats.json': {},
+        'module_history.json': { version: 1, sessions: [] },
         'GemstoneRoutes/empty.json': {},
         'RoutewalkerRoutes/empty.json': {},
         'TunnelMinerRoutes/empty.json': {},

--- a/utils/ModuleBase.js
+++ b/utils/ModuleBase.js
@@ -4,6 +4,7 @@ import { Categories } from '../gui/categories/CategorySystem';
 import { Chat } from './Chat';
 import { KeyBindUtils } from './Constants';
 import { MacroState } from './MacroState';
+import { ModuleHistory } from './ModuleHistory';
 import { Mixin } from './MixinManager';
 import { ScheduleTask } from './ScheduleTask';
 import { manager } from './SkyblockEvents';
@@ -160,6 +161,15 @@ export class ModuleBase {
                 OverlayManager.startTime(this.oid, this.isMacro);
             }
 
+            ModuleHistory.startSession(this.name, {
+                overlayId: this.oid,
+                category: this.subcategory,
+                isMacro: this.isMacro,
+                parentManaged: this.isParentManaged,
+                toggleContext,
+                getOverlayData: () => (this.oid ? OverlayManager.getSessionSnapshot(this.oid) : null),
+            });
+
             try {
                 this.onEnable();
             } catch (e) {
@@ -172,6 +182,8 @@ export class ModuleBase {
                 MacroState.onModuleDisabled(this.name, toggleContext);
                 Mixin.set('macroEnabled', MacroState.isMacroRunning());
             }
+
+            ModuleHistory.endSession(this.name, toggleContext);
 
             if (this.oid) {
                 if (this.isMacro) {

--- a/utils/ModuleBase.js
+++ b/utils/ModuleBase.js
@@ -161,14 +161,16 @@ export class ModuleBase {
                 OverlayManager.startTime(this.oid, this.isMacro);
             }
 
-            ModuleHistory.startSession(this.name, {
-                overlayId: this.oid,
-                category: this.subcategory,
-                isMacro: this.isMacro,
-                parentManaged: this.isParentManaged,
-                toggleContext,
-                getOverlayData: () => (this.oid ? OverlayManager.getSessionSnapshot(this.oid) : null),
-            });
+            if (this.isMacro) {
+                ModuleHistory.startSession(this.name, {
+                    overlayId: this.oid,
+                    category: this.subcategory,
+                    isMacro: this.isMacro,
+                    parentManaged: this.isParentManaged,
+                    toggleContext,
+                    getOverlayData: () => (this.oid ? OverlayManager.getSessionSnapshot(this.oid) : null),
+                });
+            }
 
             try {
                 this.onEnable();
@@ -183,7 +185,9 @@ export class ModuleBase {
                 Mixin.set('macroEnabled', MacroState.isMacroRunning());
             }
 
-            ModuleHistory.endSession(this.name, toggleContext);
+            if (this.isMacro) {
+                ModuleHistory.endSession(this.name, toggleContext);
+            }
 
             if (this.oid) {
                 if (this.isMacro) {

--- a/utils/ModuleHistory.js
+++ b/utils/ModuleHistory.js
@@ -1,0 +1,143 @@
+import { Utils } from './Utils';
+
+const HISTORY_FILE = 'module_history.json';
+const SAMPLE_INTERVAL_MS = 60 * 1000;
+
+class ModuleHistoryTracker {
+    constructor() {
+        this.history = this.loadHistory();
+        this.activeSessions = {};
+        this.recoverStaleSessions();
+
+        register('step', () => this.sampleDueSessions()).setFps(1);
+        register('gameUnload', () => this.endAllSessions('game_unload'));
+    }
+
+    loadHistory() {
+        const data = Utils.getConfigFile(HISTORY_FILE);
+        return data.sessions ? data : { version: 1, sessions: [] };
+    }
+
+    recoverStaleSessions() {
+        let changed = false;
+
+        this.history.sessions.forEach((session) => {
+            if (!session || !session.active) return;
+
+            const lastPoint = session.minuteData[session.minuteData.length - 1];
+            const endedAtMs = lastPoint?.timestampMs || session.enabledAtMs;
+
+            session.active = false;
+            session.disabledAtMs = endedAtMs;
+            session.disabledAt = this.toIso(endedAtMs);
+            session.durationMs = Math.max(0, endedAtMs - (session.enabledAtMs || endedAtMs));
+            session.endReason = 'startup_recovery';
+            changed = true;
+        });
+
+        if (changed) this.saveHistory();
+    }
+
+    startSession(moduleName, options = {}) {
+        if (!moduleName) return;
+
+        if (this.activeSessions[moduleName]) {
+            this.endSession(moduleName, 'restart');
+        }
+
+        const now = Date.now();
+        const session = {
+            id: `${moduleName}-${now}`,
+            module: moduleName,
+            overlayId: options.overlayId || null,
+            category: options.category || null,
+            isMacro: options.isMacro === true,
+            parentManaged: options.parentManaged === true,
+            toggleContext: options.toggleContext || 'user',
+            enabledAtMs: now,
+            enabledAt: this.toIso(now),
+            disabledAtMs: null,
+            disabledAt: null,
+            durationMs: 0,
+            active: true,
+            overlayData: null,
+            minuteData: [],
+        };
+
+        this.history.sessions.push(session);
+        this.activeSessions[moduleName] = {
+            session,
+            getOverlayData: options.getOverlayData,
+            nextSampleAt: now,
+        };
+
+        this.recordSample(moduleName, now);
+        this.activeSessions[moduleName].nextSampleAt = now + SAMPLE_INTERVAL_MS;
+        this.saveHistory();
+    }
+
+    sampleDueSessions() {
+        const now = Date.now();
+        let changed = false;
+
+        Object.keys(this.activeSessions).forEach((moduleName) => {
+            const active = this.activeSessions[moduleName];
+            if (!active || now < active.nextSampleAt) return;
+
+            this.recordSample(moduleName, now);
+            active.nextSampleAt = Math.floor(now / SAMPLE_INTERVAL_MS) * SAMPLE_INTERVAL_MS + SAMPLE_INTERVAL_MS;
+            changed = true;
+        });
+
+        if (changed) this.saveHistory();
+    }
+
+    endSession(moduleName, reason = 'disabled') {
+        const active = this.activeSessions[moduleName];
+        if (!active) return;
+
+        const now = Date.now();
+        this.recordSample(moduleName, now);
+
+        const session = active.session;
+        session.active = false;
+        session.disabledAtMs = now;
+        session.disabledAt = this.toIso(now);
+        session.durationMs = Math.max(0, now - session.enabledAtMs);
+        session.endReason = reason;
+
+        delete this.activeSessions[moduleName];
+        this.saveHistory();
+    }
+
+    endAllSessions(reason = 'disabled') {
+        Object.keys(this.activeSessions).forEach((moduleName) => this.endSession(moduleName, reason));
+    }
+
+    recordSample(moduleName, timestampMs = Date.now()) {
+        const active = this.activeSessions[moduleName];
+        if (!active) return;
+
+        const session = active.session;
+        const overlayData = active.getOverlayData ? active.getOverlayData() : null;
+        session.overlayData = overlayData;
+        session.durationMs = Math.max(0, timestampMs - session.enabledAtMs);
+        session.minuteData.push({
+            minute: Math.floor(timestampMs / SAMPLE_INTERVAL_MS),
+            timestampMs,
+            timestamp: this.toIso(timestampMs),
+            elapsedMs: session.durationMs,
+            overlayData,
+        });
+    }
+
+    saveHistory() {
+        Utils.writeConfigFile(HISTORY_FILE, this.history);
+    }
+
+    toIso(timestampMs) {
+        return new Date(timestampMs).toISOString();
+    }
+}
+
+export const ModuleHistory = new ModuleHistoryTracker();

--- a/utils/ModuleHistory.js
+++ b/utils/ModuleHistory.js
@@ -24,6 +24,7 @@ class ModuleHistoryTracker {
         this.history.sessions.forEach((session) => {
             if (!session || !session.active) return;
 
+            session.minuteData = session.minuteData || [];
             const lastPoint = session.minuteData[session.minuteData.length - 1];
             const endedAtMs = lastPoint?.timestampMs || session.enabledAtMs;
 
@@ -32,6 +33,14 @@ class ModuleHistoryTracker {
             session.disabledAt = this.toIso(endedAtMs);
             session.durationMs = Math.max(0, endedAtMs - (session.enabledAtMs || endedAtMs));
             session.endReason = 'startup_recovery';
+            session.minuteData.push({
+                type: 'end',
+                minute: Math.floor(endedAtMs / SAMPLE_INTERVAL_MS),
+                timestampMs: endedAtMs,
+                timestamp: session.disabledAt,
+                elapsedMs: session.durationMs,
+                overlayData: session.overlayData,
+            });
             changed = true;
         });
 
@@ -39,7 +48,7 @@ class ModuleHistoryTracker {
     }
 
     startSession(moduleName, options = {}) {
-        if (!moduleName) return;
+        if (!moduleName || !options.isMacro) return;
 
         if (this.activeSessions[moduleName]) {
             this.endSession(moduleName, 'restart');
@@ -71,7 +80,7 @@ class ModuleHistoryTracker {
             nextSampleAt: now,
         };
 
-        this.recordSample(moduleName, now);
+        this.recordSample(moduleName, now, 'start');
         this.activeSessions[moduleName].nextSampleAt = now + SAMPLE_INTERVAL_MS;
         this.saveHistory();
     }
@@ -84,7 +93,7 @@ class ModuleHistoryTracker {
             const active = this.activeSessions[moduleName];
             if (!active || now < active.nextSampleAt) return;
 
-            this.recordSample(moduleName, now);
+            this.recordSample(moduleName, now, 'minute');
             active.nextSampleAt = Math.floor(now / SAMPLE_INTERVAL_MS) * SAMPLE_INTERVAL_MS + SAMPLE_INTERVAL_MS;
             changed = true;
         });
@@ -97,7 +106,7 @@ class ModuleHistoryTracker {
         if (!active) return;
 
         const now = Date.now();
-        this.recordSample(moduleName, now);
+        this.recordSample(moduleName, now, 'end');
 
         const session = active.session;
         session.active = false;
@@ -114,7 +123,7 @@ class ModuleHistoryTracker {
         Object.keys(this.activeSessions).forEach((moduleName) => this.endSession(moduleName, reason));
     }
 
-    recordSample(moduleName, timestampMs = Date.now()) {
+    recordSample(moduleName, timestampMs = Date.now(), type = 'minute') {
         const active = this.activeSessions[moduleName];
         if (!active) return;
 
@@ -123,6 +132,7 @@ class ModuleHistoryTracker {
         session.overlayData = overlayData;
         session.durationMs = Math.max(0, timestampMs - session.enabledAtMs);
         session.minuteData.push({
+            type,
             minute: Math.floor(timestampMs / SAMPLE_INTERVAL_MS),
             timestampMs,
             timestamp: this.toIso(timestampMs),


### PR DESCRIPTION
### Motivation
- Introduce persistent session tracking for modules to record enable/disable events, periodic samples, durations, and overlay snapshots for later analysis.
- Ensure sessions active across restarts are recovered and closed with a clear end reason and timestamp.
- Wire session lifecycle into overlay and module lifecycle so overlay state and tracked values can be captured when modules start and stop.

### Description
- Add `utils/ModuleHistory.js` which implements `ModuleHistory` to start/end sessions, sample active sessions every minute, persist to `module_history.json`, recover stale sessions on load, and end all sessions on `gameUnload`.
- Integrate history hooks into `utils/ModuleBase.js` by calling `ModuleHistory.startSession(...)` on enable and `ModuleHistory.endSession(...)` on disable, including a `getOverlayData` callback to capture overlay snapshots.
- Add `getSessionSnapshot` and import `ModuleHistory` usage to `gui/OverlayUtils.js` to produce overlay section data and tracked values for snapshotting, and call `ModuleHistory.endAllSessions('game_unload')` from `resetAll` to ensure clean shutdown handling.
- Update `utils/Config.js` manifest to generate a new `module_history.json` with initial structure so history is persisted by the config system.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a272f735c3c8333a08bce9786981d46)