### PR TITLE
Fix PestESP tracer view bob offset

### DIFF
--- a/modules/visuals/PestESP.js
+++ b/modules/visuals/PestESP.js
@@ -5,6 +5,35 @@ import { Utils } from '../../utils/Utils';
 
 const PEST_NAMES = ['Silverfish', 'Bat'];
 const PEST_KILL_RADIUS_SQ = 12 ** 2;
+const TRACER_START_DISTANCE = 0.1;
+const DEG_TO_RAD = Math.PI / 180;
+
+function getCrosshairTracerStart() {
+    const gameRenderer = Client.getMinecraft().gameRenderer;
+    const camera = gameRenderer.getMainCamera();
+    const renderState = gameRenderer.getGameRenderState();
+    const cameraState = renderState.levelRenderState.cameraRenderState;
+    const cameraEntityState = cameraState.entityRenderState;
+    const tracerOffset = new org.joml.Vector3f(0, 0, -TRACER_START_DISTANCE);
+
+    // View bob is added after the camera rotation, so undo it to keep the origin on the screen-center crosshair.
+    if (renderState.optionsRenderState.bobView && cameraEntityState.isPlayer) {
+        const walk = cameraEntityState.backwardsInterpolatedWalkDistance;
+        const bob = cameraEntityState.bob;
+        const walkRadians = walk * Math.PI;
+        const viewBob = new org.joml.Matrix4f()
+            .translate(Math.sin(walkRadians) * bob * 0.5, -Math.abs(Math.cos(walkRadians) * bob), 0)
+            .rotateZ(Math.sin(walkRadians) * bob * 3 * DEG_TO_RAD)
+            .rotateX(Math.abs(Math.cos(walkRadians - 0.2) * bob) * 5 * DEG_TO_RAD)
+            .invert();
+
+        viewBob.transformPosition(tracerOffset);
+    }
+
+    new org.joml.Matrix4f(cameraState.viewRotationMatrix).invert().transformDirection(tracerOffset);
+    const cameraPos = camera.position();
+    return new Vec3d(cameraPos.x() + tracerOffset.x(), cameraPos.y() + tracerOffset.y(), cameraPos.z() + tracerOffset.z());
+}
 
 export function getNearbyPest() {
     const eyes = Player.getPlayer()?.getEyePosition();
@@ -63,11 +92,13 @@ class PestESP extends ModuleBase {
             () => this.enabled && Utils.area() === 'Garden',
             'postRenderWorld',
             () => {
+                let tracerStart = null;
                 this.persistentPests.forEach((data) => {
                     if (!data.entity || data.entity.isDead()) return;
                     RenderUtils.drawHitbox(data.entity.toMC(), new RenderColor(255, 0, 0, 100), 5, false);
 
-                    RenderUtils.drawTracer(new Vec3d(data.x, data.y, data.z), new RenderColor(255, 0, 0, 255), 2, false);
+                    if (!tracerStart) tracerStart = getCrosshairTracerStart();
+                    RenderUtils.drawLine(tracerStart, new Vec3d(data.x, data.y, data.z), new RenderColor(255, 0, 0, 255), 2, false);
                 });
             }
         );


### PR DESCRIPTION
Summary: Compensate Minecraft view-bob translation and rotation when calculating the PestESP tracer origin transform the corrected camera-space origin back into world space reuse one tracer origin for all visible pests in a frame

Why: The existing RenderUtils.drawTracer origin follows the unbobbed camera direction, while the world is rendered with an additional view-bob matrix. This makes the tracer appear attached to the player body instead of the screen-center crosshair. 

Validation: Formatted PestESP.js with the repository Prettier configuration. git diff --check passes. In-game verification successfully passes as well.