### PR TITLE
Limit ban log webhooks to Hypixel

### DIFF
--- a/modules/other/Failsafes.js
+++ b/modules/other/Failsafes.js
@@ -141,7 +141,17 @@ class Failsafes extends ModuleBase {
         return text.includes('banned') || text.includes('cheating') || text.includes('boosting') || text.includes('security');
     }
 
+    isHypixelServer() {
+        const serverAddress = Client.getMinecraft()?.getCurrentServer()?.ip?.toLowerCase();
+        if (!serverAddress) return false;
+
+        const hostname = serverAddress.split(':')[0];
+        return hostname === 'hypixel.net' || hostname.endsWith('.hypixel.net');
+    }
+
     postBanLog(reason) {
+        if (!this.isHypixelServer()) return;
+
         const now = Date.now();
         if (now - this.lastBanLogTime < 60000) return;
         this.lastBanLogTime = now;


### PR DESCRIPTION
### Motivation
- Ensure ban log webhooks are only sent for Hypixel so bans on other servers are not forwarded.

### Description
- Add `isHypixelServer()` which reads `Client.getMinecraft()?.getCurrentServer()?.ip` and make `postBanLog` return early unless the hostname is `hypixel.net` or ends with `.hypixel.net`.

### Testing
- The repository has no automated test runner so no automated tests were run per project instructions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a591e239e70832caa6608bd3c4ea551)