### PR TITLE
feat: add failsafe customization, PiP mode, scheduler mini-breaks, macro improvements, and bug fixes

### DIFF
--- a/CommissionMacro.js
+++ b/CommissionMacro.js
@@ -1,0 +1,1025 @@
+import { OverlayManager } from '../../gui/OverlayUtils';
+import { notificationManager } from '../../gui/NotificationManager';
+import { CommissionClaimer } from '../../utils/CommissionUtils';
+import { MathUtils } from '../../utils/Math';
+import { MacroState } from '../../utils/MacroState';
+import { MiningUtils } from '../../utils/MiningUtils';
+import { ModuleBase } from '../../utils/ModuleBase';
+import { finiteNumber } from '../../utils/NumberUtils';
+import { EtherwarpPathfinder } from '../../utils/pathfinder/EtherwarpPathfinder';
+import Pathfinder from '../../utils/pathfinder/PathFinder';
+import { Guis } from '../../utils/player/Inventory';
+import { manager } from '../../utils/SkyblockEvents';
+import { TabListUtils } from '../../utils/TabListUtils';
+import { Mouse } from '../../utils/Ungrab';
+import { Utils } from '../../utils/Utils';
+import { CombatBot } from '../combat/CombatBot';
+import { COMMISSION_DATA, EMISSARY_LOCATIONS, MOB_CONFIGS, TRASH_ITEMS } from './CommissionData';
+import { MiningBot } from './MiningBot';
+
+const STATES = {
+    IDLE: 'Idle',
+    CHOOSING: 'Choosing Commission',
+    TRAVELING: 'Traveling to Location',
+    WAITING_GUI_CLOSE: 'Closing GUI',
+    MINING: 'Mining',
+    SLAYER: 'Killing Mobs',
+    SELLING: 'Selling Items',
+    REFUELING: 'Refueling Drill',
+    CLAIMING: 'Claiming Rewards',
+};
+const TRAVEL_MODES = ['Walk', 'Etherwarp'];
+
+class CommissionMacro extends ModuleBase {
+    constructor() {
+        super({
+            name: 'Commission Macro',
+            subcategory: 'Mining',
+            description: 'Completes Commissions for you',
+            tooltip: 'Completes Commissions for you (Dwarven).',
+            theme: '#4cdfd2',
+            autoDisableOnWorldUnload: false,
+            isMacro: true,
+        });
+        this.bindToggleKey();
+
+        this.currentState = STATES.IDLE;
+        this.travelMode = TRAVEL_MODES[0];
+        this.avoidanceRadius = 10;
+        this.goblinWeaponSlot = 1;
+        this.emissariesUnlocked = true;
+        this.pauseTicks = 0;
+        this.rodSwapEnabled = false;
+        this.pathingAvoidanceBreachAt = null;
+        this.lastAvoidanceRepathAt = 0;
+        this.currentPathWaypoint = null;
+        this.currentPathWaypoints = [];
+
+        this.commissions = [];
+        this.currentCommission = null;
+        this.currentMobConfig = null;
+        this.mobWhitelist = new Set();
+        this.savedState = null;
+        this.awaitingTabUpdate = false;
+        this.ignoreTabUpdatesUntil = 0;
+        this.lastCommissionSyncSource = null;
+        this.travelPurpose = null;
+
+        this.drill = null;
+        this.pickaxe = null;
+        this.weapon = null;
+        this.isActualDrill = false;
+        this.miningSpeed = 0;
+        this.lastCompletedCommissionName = null;
+        this.lastCommissionName = null;
+        this.commissionClaimer = new CommissionClaimer({
+            getLocations: () => this.getAvailableEmissaryLocations(),
+            ensureToolEquipped: () => this.ensureDrillEquippedForEmissaryClaim(),
+            isClaiming: () => this.enabled && this.currentState === STATES.CLAIMING,
+            delay: (ticks) => this.delay(ticks),
+            onClaimsExhausted: (container) => {
+                this.updateCommissionsFromGui(container);
+                Guis.closeInv();
+                this.setState(STATES.WAITING_GUI_CLOSE);
+            },
+            onPathStart: () => {
+                this.travelPurpose = 'EMISSARY';
+            },
+            onPathFailed: () => this.setState(STATES.CHOOSING),
+            canInteract: () => !this.emissariesUnlocked || this.checkEmissaryUnlocked(),
+            useEtherwarp: () => this.travelMode === 'Etherwarp',
+            rodSlot: () => this.getRodSwapSlot(),
+        });
+
+        this.addMultiToggle(
+            'Travel Mode',
+            TRAVEL_MODES,
+            true,
+            (selected) => {
+                const enabled = Array.isArray(selected) ? selected.find((item) => item.enabled) : null;
+                this.travelMode = enabled?.name || TRAVEL_MODES[0];
+            },
+            'How the macro travels to commission locations.',
+            TRAVEL_MODES[0]
+        );
+
+        this.createOverlay(
+            [
+                {
+                    title: 'Status',
+                    data: {
+                        State: () => this.currentState,
+                        Commission: () => this.currentCommission?.name || 'None',
+                        Progress: () => this.getCommissionProgressDisplay(),
+                        Tool: () => this.getTruncatedToolName(),
+                    },
+                },
+                {
+                    title: 'Profits',
+                    data: {
+                        'Completed Commissions': () => this.getCompletedCommissions(),
+                        'Last Commission': () => this.getLastCommissionDisplay(),
+                        'Commissions/hr': () => this.getCommissionsPerHourDisplay(),
+                    },
+                },
+            ],
+            {
+                sessionTrackedValues: {
+                    commissionsCompleted: 0,
+                },
+            }
+        );
+
+        this.on('step', () => {
+            const newCommissions = TabListUtils.readCommissions();
+            this.updateCommissionsIfChanged(newCommissions);
+        }).setDelay(1);
+
+        this.on('tick', () => this.runLogic());
+
+        manager.subscribe('commissioncomplete', () => {
+            if (!this.enabled) return;
+            OverlayManager.incrementTrackedValue(this.oid, 'commissionsCompleted');
+            this.onCommissionComplete();
+        });
+
+        manager.subscribe('fullinventory', () => {
+            if (this.enabled && this.currentState === STATES.MINING) this.onInventoryFull();
+        });
+
+        manager.subscribe('emptydrill', () => {
+            if (this.enabled && (this.currentState === STATES.MINING || this.currentState === STATES.CLAIMING)) this.onDrillEmpty();
+        });
+
+        manager.subscribe('death', () => {
+            if (this.enabled) this.delayedReset(10);
+        });
+
+        manager.subscribe('serverchange', () => {
+            if (this.enabled) this.delayedReset(67);
+        });
+
+        this.on('worldUnload', () => {
+            this.delayedReset(67);
+        });
+
+        this.addSlider(
+            'Avoidance Radius',
+            0,
+            30,
+            10,
+            (value) => {
+                this.avoidanceRadius = value;
+            },
+            'How close players/Star Sentries can be to a mining spot before it is considered occupied.'
+        );
+
+        this.addSlider(
+            'Weapon Slot (Goblin)',
+            1,
+            8,
+            1,
+            (value) => {
+                this.goblinWeaponSlot = value;
+            },
+            'Hotbar slot with weapon for Goblin Slayer (1-8)'
+        );
+
+        this.addToggle(
+            'Rod Swap on Commission Claim',
+            (value) => {
+                this.rodSwapEnabled = value;
+            },
+            'Swaps to a rod in the hotbar and right-clicks the emissary to claim commissions.'
+        );
+    }
+
+    getCommissionProgressDisplay() {
+        const currentCommName = this.currentCommission?.name || 'None';
+        const currentCommData = this.commissions.find((c) => c.name === currentCommName);
+        const currentProgress = currentCommData?.progress || 0;
+        return currentProgress === 1 ? 'DONE' : `${(currentProgress * 100).toFixed(0)}%`;
+    }
+
+    getLastCommissionDisplay() {
+        return this.lastCommissionName || 'None';
+    }
+
+    getCompletedCommissions() {
+        return OverlayManager.getTrackedValue(this.oid, 'commissionsCompleted', 0);
+    }
+
+    getCommissionsPerHourDisplay() {
+        const elapsedMs = MacroState.getModuleElapsedMs(this.name);
+        if (elapsedMs <= 0) return '0.00';
+        const hours = elapsedMs / 3600000;
+        const rate = this.getCompletedCommissions() / hours;
+        if (!Number.isFinite(rate)) return '0.00';
+        return rate.toFixed(2);
+    }
+
+    getTruncatedToolName() {
+        const toolInfo = this.getToolDisplay();
+        const maxLen = 45;
+        let name = toolInfo.name;
+        if (name.length > maxLen) {
+            name = name.substring(0, maxLen - 2) + '..';
+        }
+        return name;
+    }
+
+    getToolDisplay() {
+        if (this.isGoblinSlayerWithWeapon()) {
+            return {
+                type: 'Weapon',
+                name: this.weapon.name,
+            };
+        }
+
+        if (this.drill) {
+            const fullName = ChatLib.removeFormatting(this.drill.item.getName());
+            if (this.isActualDrill) {
+                return {
+                    type: 'Drill',
+                    name: fullName,
+                };
+            }
+            return {
+                type: 'Pickaxe',
+                name: fullName,
+            };
+        }
+
+        return {
+            type: 'None',
+            name: 'None',
+        };
+    }
+
+    isGoblinSlayerWithWeapon() {
+        return this.currentState === STATES.SLAYER && this.currentCommission?.name === 'Goblin Slayer' && this.weapon;
+    }
+
+    onEnable() {
+        this.message('&aEnabled');
+        this.emissariesUnlocked = true;
+
+        const drills = MiningUtils.getDrills();
+        this.drill = drills.drill;
+        this.pickaxe = this.drill;
+
+        if (!this.drill) {
+            this.message('&cNo drill or pickaxe found in hotbar!');
+            this.toggle(false);
+            return;
+        }
+
+        const itemName = ChatLib.removeFormatting(this.drill.item.getName());
+        this.isActualDrill = itemName.includes('Drill') || itemName.includes('Gauntlet');
+
+        this.weapon = this.getWeaponFromSlot();
+        if (!this.weapon) {
+            notificationManager.add(`No weapon found in slot ${this.goblinWeaponSlot}`, 'Goblin commissions will be skipped.', 'ERROR', '5000');
+        }
+
+        this.miningSpeed = MiningUtils.getMiningSpeed('Dwarven Mines');
+        if (!this.miningSpeed) {
+            notificationManager.add('No mining speed saved!', "Run '/v5 mining stats' first.", 'ERROR', '5000');
+            this.toggle(false);
+            return;
+        }
+
+        Mouse.ungrab();
+        this.resetState();
+    }
+
+    onDisable() {
+        this.message('&cDisabled');
+        this.resetState();
+
+        Mouse.regrab();
+    }
+
+    resetState() {
+        this.currentState = STATES.IDLE;
+        this.commissions = [];
+        this.currentCommission = null;
+        this.currentMobConfig = null;
+        this.mobWhitelist.clear();
+        this.savedState = null;
+        this.travelPurpose = null;
+        this.pauseTicks = 0;
+        this.awaitingTabUpdate = false;
+        this.ignoreTabUpdatesUntil = 0;
+        this.lastCommissionSyncSource = null;
+        this.lastCompletedCommissionName = null;
+        this.lastCommissionName = null;
+        this.commissionClaimer.cancelNpcRotation();
+        this.areaCheckTime = null;
+        this.pathingAvoidanceBreachAt = null;
+        this.lastAvoidanceRepathAt = 0;
+        this.currentPathWaypoint = null;
+        this.currentPathWaypoints = [];
+
+        MiningBot.toggle(false, true);
+        CombatBot.clearExternalTargets();
+        CombatBot.toggle(false);
+        EtherwarpPathfinder.cancel(true);
+        Pathfinder.resetPath(true);
+    }
+
+    delayedReset(delay) {
+        this.resetState();
+        this.delay(delay);
+    }
+
+    setState(newState) {
+        this.currentState = newState;
+    }
+
+    runLogic() {
+        if (!this.enabled) return;
+        MiningBot.setCost(MiningBot.mithrilCosts);
+
+        this.commissionClaimer.cancelNpcRotationIfPathing();
+        this.handlePathingAvoidance();
+
+        if (this.pauseTicks > 0) {
+            this.pauseTicks--;
+            return;
+        }
+
+        switch (this.currentState) {
+            case STATES.IDLE:
+                this.handleIdle();
+                break;
+            case STATES.CHOOSING:
+                this.handleChoosing();
+                break;
+            case STATES.WAITING_GUI_CLOSE:
+                this.handleWaitingGuiClose();
+                break;
+            case STATES.SLAYER:
+                this.handleSlayer();
+                break;
+            case STATES.SELLING:
+                this.handleSelling();
+                break;
+            case STATES.CLAIMING:
+                this.handleClaiming();
+                break;
+            default:
+                break;
+        }
+    }
+
+    handleIdle() {
+        this.setState(STATES.CHOOSING);
+    }
+
+    handleChoosing() {
+        const area = Utils.area();
+        const now = Date.now();
+        if (area !== 'Dwarven Mines') {
+            if (!this.areaCheckTime) {
+                this.message('&eNot in Dwarven Mines, warping...');
+                ChatLib.command('warpforge');
+                this.areaCheckTime = now;
+                return;
+            }
+            if (now - this.areaCheckTime > 10000) {
+                ChatLib.command('warpforge');
+                this.areaCheckTime = now;
+            }
+            return;
+        }
+        this.areaCheckTime = null;
+
+        const newCommissions = TabListUtils.readCommissions();
+        this.updateCommissionsIfChanged(newCommissions);
+
+        if (this.shouldWaitForLastCompleted()) return;
+        if (this.awaitingTabUpdate) return;
+
+        const completedCommission = this.findCompletedCommission();
+        if (completedCommission) {
+            if (
+                this.lastCompletedCommissionName &&
+                completedCommission.name === this.lastCompletedCommissionName &&
+                this.ignoreTabUpdatesUntil &&
+                now < this.ignoreTabUpdatesUntil
+            ) {
+                this.awaitingTabUpdate = true;
+                return;
+            }
+            this.currentCommission = completedCommission;
+            this.onCommissionComplete();
+            return;
+        }
+
+        const activeCommissions = this.getActiveCommissions();
+        if (activeCommissions.length === 0) {
+            this.message('No commissions detected.');
+            this.message('Ensure commissions are enabled in /tab');
+            this.message('You might have to speak to the king first.');
+            this.toggle(false);
+            return;
+        }
+
+        const supportedTasks = this.getSupportedTasks(activeCommissions);
+        if (supportedTasks.length === 0) {
+            this.message('&eNo supported commissions available.');
+            this.toggle(false);
+            return;
+        }
+
+        const avoidEntities = this.getAvoidanceEntities();
+        const chosenCommission = this.findAvailableCommission(supportedTasks, avoidEntities);
+
+        if (chosenCommission) {
+            this.startCommission(chosenCommission);
+        } else {
+            this.handleNoAvailableSpots();
+        }
+    }
+
+    shouldWaitForLastCompleted() {
+        if (!this.lastCompletedCommissionName) return false;
+        const staleCommission = this.commissions.find((c) => c.name === this.lastCompletedCommissionName && c.progress > 0);
+        if (staleCommission && staleCommission.progress === 1) return true;
+        if (staleCommission && staleCommission.progress < 1) {
+            this.lastCompletedCommissionName = null;
+            return false;
+        }
+        this.lastCompletedCommissionName = null;
+        return false;
+    }
+
+    findCompletedCommission() {
+        return this.commissions.find((c) => {
+            if (c.progress !== 1) return false;
+            return COMMISSION_DATA.some((d) => d.names.includes(c.name));
+        });
+    }
+
+    getActiveCommissions() {
+        return this.commissions.filter((c) => c.progress < 1);
+    }
+
+    getSupportedTasks(activeCommissions) {
+        return activeCommissions
+            .map((tabComm) => this.mergeCommissionData(tabComm))
+            .filter((task) => this.isSupportedTask(task))
+            .sort((a, b) => a.cost - b.cost);
+    }
+
+    mergeCommissionData(tabComm) {
+        const data = COMMISSION_DATA.find((d) => d.names.includes(tabComm.name));
+        if (!data) return null;
+
+        const merged = { ...tabComm, ...data };
+
+        if (data.useAllMiningWaypoints) {
+            merged.waypoints = COMMISSION_DATA.filter((d) => d.type === 'MINING' && !d.useAllMiningWaypoints).reduce((acc, d) => acc.concat(d.waypoints), []);
+        }
+
+        return merged;
+    }
+
+    isSupportedTask(task) {
+        if (!task) return false;
+
+        if (task.type === 'MINING') {
+            return !task.name.includes('Goblin') || !!this.weapon;
+        }
+
+        if (task.type === 'SLAYER') {
+            return task.name !== 'Goblin Slayer' || !!this.weapon;
+        }
+
+        return false;
+    }
+
+    getAvoidanceEntities() {
+        if (this.avoidanceRadius <= 0) return [];
+        return World.getAllPlayers().filter((entity) => {
+            if (entity.getUUID().equals(Player.getUUID())) return false;
+
+            const isPlayer = entity.getUUID().version() === 4;
+            const isCrystalSentry = entity.getName().includes('Crystal Sentry');
+            return isPlayer || isCrystalSentry;
+        });
+    }
+
+    findAvailableCommission(supportedTasks, avoidEntities) {
+        for (const task of supportedTasks) {
+            const safeWaypoints = this.getSafeWaypoints(task, avoidEntities);
+            if (safeWaypoints.length > 0) return { task, waypoints: safeWaypoints };
+        }
+        return null;
+    }
+
+    getSafeWaypoints(task, avoidEntities) {
+        if (this.avoidanceRadius <= 0) return task.waypoints;
+        return task.waypoints.filter((waypoint) => {
+            return !avoidEntities.some((entity) => {
+                const distance = this.getDistance(entity.getX(), entity.getY(), entity.getZ(), ...waypoint);
+                return distance < this.avoidanceRadius;
+            });
+        });
+    }
+
+    getClosestWaypoint(waypoints) {
+        const playerPos = { x: Player.getX(), y: Player.getY(), z: Player.getZ() };
+        return waypoints.reduce((closest, current) => {
+            const closestDist = this.getDistance(playerPos.x, playerPos.y, playerPos.z, ...closest);
+            const currentDist = this.getDistance(playerPos.x, playerPos.y, playerPos.z, ...current);
+            return currentDist < closestDist ? current : closest;
+        });
+    }
+
+    startCommission(chosenCommission) {
+        const { task, waypoints } = chosenCommission;
+        this.currentCommission = task;
+        this.travelPurpose = task.type;
+        this.pathingAvoidanceBreachAt = null;
+
+        this.message(`Starting &e${task.name}&f commission.`);
+
+        this.currentPathWaypoints = waypoints.slice();
+        this.currentPathWaypoint = this.getClosestWaypoint(waypoints);
+        this.setState(STATES.TRAVELING);
+        if (this.travelMode === 'Etherwarp') {
+            let walking = false;
+            const fallback = () => {
+                if (walking || this.currentState !== STATES.TRAVELING) return;
+                walking = true;
+                Pathfinder.findPath(waypoints, (success) => this.onPathComplete(success));
+            };
+            const started = EtherwarpPathfinder.findPath(waypoints, {
+                silent: true,
+                onSuccess: () => this.onPathComplete(true),
+                onFail: fallback,
+            });
+            if (!started) fallback();
+            return;
+        }
+        Pathfinder.findPath(waypoints, (success) => this.onPathComplete(success));
+    }
+
+    handleNoAvailableSpots() {
+        this.message('No available spots! Finding new lobby');
+        ChatLib.command('hub');
+        this.resetState();
+        this.delay(80);
+    }
+
+    handleSlayer() {
+        if (!this.currentMobConfig) {
+            CombatBot.clearExternalTargets();
+            CombatBot.toggle(false, true);
+            return;
+        }
+
+        const mobs = CombatBot.findMob(this.currentMobConfig, this.mobWhitelist);
+        if (!mobs || mobs.length === 0) {
+            CombatBot.setExternalTargets([]);
+            return;
+        }
+
+        CombatBot.setExternalTargets(mobs);
+        if (!CombatBot.enabled) {
+            CombatBot.toggle(true, true);
+        }
+    }
+
+    handleSelling() {
+        // COMPLETELY UNTESTED :)
+        if (Guis.guiName() !== 'Trades') {
+            ChatLib.command('trades');
+            this.delay(10);
+            return;
+        }
+
+        const soldItem = this.sellNextTrashItem();
+        if (soldItem) return;
+
+        // No more items to sell
+        Guis.closeInv();
+        this.restoreStateAfterSelling();
+    }
+
+    sellNextTrashItem() {
+        const container = Player.getContainer();
+        if (!container) return false;
+
+        const items = container.getItems();
+        if (!items || items.length <= 54) return false;
+
+        for (let i = 54; i < items.length; i++) {
+            const item = items[i];
+            if (!item) continue;
+
+            const name = ChatLib.removeFormatting(item.getName());
+            const isTrash = TRASH_ITEMS.some((trash) => name.includes(trash));
+            const isNotEquipment = !name.includes('Drill') && !name.includes('Pickaxe') && !name.includes('Minecart') && !name.includes('Tasty');
+
+            if (isTrash && isNotEquipment) {
+                Guis.clickSlot(i, false);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    restoreStateAfterSelling() {
+        if (this.savedState) {
+            this.setState(this.savedState);
+            if (this.savedState === STATES.MINING) this.startMining();
+            this.savedState = null;
+        } else {
+            this.setState(STATES.CHOOSING);
+        }
+    }
+
+    handleClaiming() {
+        this.commissionClaimer.handle();
+    }
+
+    getRodSwapSlot() {
+        if (!this.rodSwapEnabled) return -1;
+        return Guis.findItemInHotbar('Rod');
+    }
+    ensureDrillEquippedForEmissaryClaim() {
+        if (!this.drill) {
+            const drills = MiningUtils.getDrills();
+            this.drill = drills.drill;
+            this.pickaxe = this.drill;
+        }
+
+        if (!this.drill) return true;
+
+        if (Player.getHeldItemIndex() !== this.drill.slot) {
+            Guis.setItemSlot(this.drill.slot);
+            this.delay(3);
+            return false;
+        }
+
+        return true;
+   }
+
+    getAvailableEmissaryLocations() {
+        return this.emissariesUnlocked ? EMISSARY_LOCATIONS : [EMISSARY_LOCATIONS[0]];
+    }
+
+    checkEmissaryUnlocked() {
+        if (!World.getAllEntities().find((e) => e.getName().includes('Emissary'))) {
+            this.emissariesUnlocked = false;
+            this.message('Emissary not found! Reverting to king.');
+            return false;
+        }
+        return true;
+    }
+
+    updateCommissionsFromGui(container) {
+        const newCommissions = MiningUtils.readCommissionsFromGui(container, (name) => COMMISSION_DATA.some((d) => d.names.includes(name)));
+
+        if (newCommissions.length > 0) {
+            this.commissions = newCommissions;
+            this.awaitingTabUpdate = false;
+            this.lastCommissionSyncSource = 'GUI';
+            this.ignoreTabUpdatesUntil = Date.now() + 5000;
+
+            const currentName = this.currentCommission?.name;
+            const matching = currentName ? this.commissions.find((c) => c.name === currentName) : null;
+            if (!matching || matching.progress === 1) {
+                this.currentCommission = null;
+            }
+        }
+    }
+
+    handleWaitingGuiClose() {
+        if (Client.isInGui()) {
+            return;
+        }
+
+        this.refreshDrillReference();
+        this.setState(STATES.CHOOSING);
+    }
+
+    refreshDrillReference() {
+        const drills = MiningUtils.getDrills();
+        this.drill = drills.drill;
+        this.pickaxe = this.drill;
+
+        if (this.drill) {
+            const itemName = ChatLib.removeFormatting(this.drill.item.getName());
+            this.isActualDrill = itemName.includes('Drill') || itemName.includes('Gauntlet');
+            Guis.setItemSlot(this.drill.slot);
+        }
+    }
+
+    delay(ticks) {
+        this.pauseTicks = Math.max(0, Math.floor(finiteNumber(ticks)));
+    }
+
+    isTravelMiningPathing() {
+        return this.travelMode === 'Walk' && this.currentState === STATES.TRAVELING && this.currentCommission?.type === 'MINING' && Pathfinder.isPathing();
+    }
+
+    handlePathingAvoidance() {
+        if (!this.isTravelMiningPathing() || this.avoidanceRadius <= 0) {
+            this.pathingAvoidanceBreachAt = null;
+            return;
+        }
+
+        this.updateCurrentPathWaypointFromResult();
+        if (!this.currentPathWaypoint) {
+            this.pathingAvoidanceBreachAt = null;
+            return;
+        }
+
+        const avoidEntities = this.getAvoidanceEntities();
+        const isBreached = avoidEntities.some((entity) => {
+            const distance = this.getDistance(entity.getX(), entity.getY(), entity.getZ(), ...this.currentPathWaypoint);
+            return distance < this.avoidanceRadius;
+        });
+
+        if (!isBreached) {
+            this.pathingAvoidanceBreachAt = null;
+            return;
+        }
+
+        const now = Date.now();
+        if (!this.pathingAvoidanceBreachAt) {
+            this.pathingAvoidanceBreachAt = now;
+            return;
+        }
+
+        if (now - this.pathingAvoidanceBreachAt < 5000) return;
+        if (now - this.lastAvoidanceRepathAt < 2000) return;
+
+        const safeWaypoints = this.getSafeWaypoints(this.currentCommission, avoidEntities).filter(
+            (waypoint) => !this.isSameWaypoint(waypoint, this.currentPathWaypoint)
+        );
+        if (safeWaypoints.length === 0) return;
+
+        this.currentPathWaypoints = safeWaypoints;
+        this.currentPathWaypoint = this.getClosestWaypoint(safeWaypoints);
+        this.pathingAvoidanceBreachAt = null;
+        this.lastAvoidanceRepathAt = now;
+
+        this.message('&eAvoidance radius breached for 5s, repathing to a different vein...');
+        Pathfinder.resetPath();
+        Pathfinder.findPath(safeWaypoints, (success) => this.onPathComplete(success));
+    }
+
+    isSameWaypoint(a, b) {
+        return a[0] === b[0] && a[1] === b[1] && a[2] === b[2];
+    }
+
+    getDistance(x1, y1, z1, x2, y2, z2) {
+        return MathUtils.fastDistance(x1, y1, z1, x2, y2, z2);
+    }
+
+    updateCurrentPathWaypointFromResult() {
+        if (!this.currentPathWaypoints || this.currentPathWaypoints.length === 0) return;
+
+        const result = Pathfinder.getResult();
+        const path = result?.path;
+        if (!path || path.length === 0) return;
+
+        const pathEnd = path[path.length - 1];
+        if (!pathEnd) return;
+
+        let bestWaypoint = this.currentPathWaypoints[0];
+        let bestDistanceSq = Number.MAX_VALUE;
+
+        this.currentPathWaypoints.forEach((waypoint) => {
+            const dx = pathEnd.x - waypoint[0];
+            const dy = pathEnd.y - (waypoint[1] + 1);
+            const dz = pathEnd.z - waypoint[2];
+            const distanceSq = dx * dx + dy * dy + dz * dz;
+            if (distanceSq < bestDistanceSq) {
+                bestDistanceSq = distanceSq;
+                bestWaypoint = waypoint;
+            }
+        });
+
+        this.currentPathWaypoint = bestWaypoint;
+    }
+
+    onPathComplete(success) {
+        if (!this.enabled) return;
+        if (!success) {
+            this.onPathFail();
+            return;
+        }
+
+        this.pathingAvoidanceBreachAt = null;
+        this.currentPathWaypoint = null;
+        this.currentPathWaypoints = [];
+
+        if (this.travelPurpose === 'EMISSARY') {
+            this.travelPurpose = null;
+            this.setState(STATES.CLAIMING);
+            return;
+        }
+
+        const type = this.currentCommission?.type;
+        if (type === 'MINING') {
+            this.setState(STATES.MINING);
+            this.startMining();
+        } else if (type === 'SLAYER') {
+            this.setState(STATES.SLAYER);
+            this.startSlayer();
+        } else {
+            this.setState(STATES.IDLE);
+        }
+
+        this.travelPurpose = null;
+    }
+
+    onPathFail() {
+        if (!this.enabled) return;
+        this.message(`&cFailed to find a path for &b${this.currentCommission?.name || 'Unknown'}. Retrying...`);
+        this.pathingAvoidanceBreachAt = null;
+        this.currentPathWaypoint = null;
+        this.currentPathWaypoints = [];
+        this.currentCommission = null;
+        this.setState(STATES.IDLE);
+    }
+
+    startMining() {
+        if (Client.isInGui()) {
+            this.message('&eWaiting for GUI to close before mining...');
+            this.setState(STATES.WAITING_GUI_CLOSE);
+            return;
+        }
+
+        const drills = MiningUtils.getDrills();
+        this.drill = drills.drill;
+
+        if (!this.drill) {
+            notificationManager.add('No drill or pickaxe found!', 'What happened?', 'ERROR', '5000');
+            this.toggle(false);
+            return;
+        }
+
+        const itemName = ChatLib.removeFormatting(this.drill.item.getName());
+        this.isActualDrill = itemName.includes('Drill') || itemName.includes('Gauntlet');
+
+        Guis.setItemSlot(this.drill.slot);
+
+        const isTitaniumCommission = this.currentCommission.name.includes('Titanium');
+        MiningBot.setPrioritizeTitanium(isTitaniumCommission);
+        MiningBot.setPrioritizeGrayMithril(true);
+
+        MiningBot.toggle(true, true);
+    }
+
+    startSlayer() {
+        const name = this.currentCommission.name;
+        let mobType;
+
+        if (name === 'Goblin Slayer') {
+            mobType = 'goblin';
+            Guis.setItemSlot(this.weapon.slot);
+        } else if (name === 'Glacite Walker Slayer' || name === 'Mines Slayer' || name === 'Treasure Hoarder Puncher') {
+            mobType = name === 'Glacite Walker Slayer' || name === 'Mines Slayer' ? 'icewalker' : 'treasure';
+            Guis.setItemSlot(this.pickaxe.slot);
+        } else {
+            this.toggle(false);
+            return;
+        }
+
+        this.currentMobConfig = MOB_CONFIGS[mobType];
+        if (!this.currentMobConfig) {
+            this.toggle(false);
+            return;
+        }
+
+        CombatBot.setExternalTargets([]);
+        if (!CombatBot.enabled) {
+            CombatBot.toggle(true, true);
+        }
+    }
+
+    onCommissionComplete() {
+        if (this.currentState === STATES.REFUELING) return;
+
+        EtherwarpPathfinder.cancel(true);
+        Pathfinder.resetPath();
+        MiningBot.toggle(false, true);
+
+        CombatBot.clearExternalTargets();
+        CombatBot.toggle(false, true);
+
+        this.travelPurpose = null;
+        this.currentPathWaypoint = null;
+        this.currentPathWaypoints = [];
+        this.lastCompletedCommissionName = this.currentCommission?.name || null;
+        this.lastCommissionName = this.currentCommission?.name || null;
+        this.awaitingTabUpdate = true;
+        this.setState(STATES.CLAIMING);
+    }
+
+    onInventoryFull() {
+        this.message('&eInventory full! Selling items...');
+        MiningBot.toggle(false, true);
+        this.savedState = this.currentState;
+        this.setState(STATES.SELLING);
+    }
+
+    onDrillEmpty() {
+        if (!this.isActualDrill) {
+            return;
+        }
+
+        const stateAfterRefueling = this.currentState === STATES.CLAIMING ? STATES.CLAIMING : STATES.IDLE;
+        this.commissionClaimer.cancelNpcRotation();
+
+        this.message('&eDrill empty! Refueling...');
+        MiningBot.toggle(false, true);
+        this.setState(STATES.REFUELING);
+
+        MiningUtils.doRefueling(true, (success) => {
+            if (!success) {
+                this.message('&cRefueling failed!');
+                this.toggle(false);
+                return;
+            }
+
+            this.message('&aRefueling successful!');
+            const drills = MiningUtils.getDrills();
+            this.drill = drills.drill;
+
+            if (this.drill) {
+                const itemName = ChatLib.removeFormatting(this.drill.item.getName());
+                this.isActualDrill = itemName.includes('Drill') || itemName.includes('Gauntlet');
+            }
+
+            this.setState(stateAfterRefueling);
+        });
+    }
+
+    getWeaponFromSlot() {
+        const slot = this.goblinWeaponSlot - 1;
+        const item = Player.getInventory().getStackInSlot(slot);
+        if (!item) return null;
+
+        const name = ChatLib.removeFormatting(item.getName());
+        return name.includes('Mithril') || name.includes('Titanium') || name === '' ? null : { slot, name };
+    }
+
+    commissionsEqual(a, b) {
+        if (a === b) return true;
+        if (!Array.isArray(a) || !Array.isArray(b)) return false;
+        return (
+            a.length === b.length &&
+            a.every((left, i) => {
+                const right = b[i];
+                if (!left || !right) return false;
+                return left.name === right.name && left.progress === right.progress;
+            })
+        );
+    }
+
+    updateCommissionsIfChanged(newCommissions) {
+        if (this.commissionsEqual(this.commissions, newCommissions)) return;
+
+        const now = Date.now();
+        if (this.ignoreTabUpdatesUntil && now < this.ignoreTabUpdatesUntil && this.lastCommissionSyncSource === 'GUI') {
+            return;
+        }
+
+        if (this.ignoreTabUpdatesUntil && now < this.ignoreTabUpdatesUntil && this.lastCompletedCommissionName) {
+            const staleCompleted = newCommissions.find((c) => c.name === this.lastCompletedCommissionName && c.progress === 1);
+            if (staleCompleted) return;
+            this.ignoreTabUpdatesUntil = 0;
+        } else if (this.ignoreTabUpdatesUntil && now >= this.ignoreTabUpdatesUntil) {
+            this.ignoreTabUpdatesUntil = 0;
+        }
+
+        this.commissions = newCommissions;
+        this.lastCommissionSyncSource = 'TAB';
+
+        if (this.awaitingTabUpdate) {
+            const stillCompleted = this.commissions.some((c) => {
+                if (c.progress !== 1) return false;
+                return COMMISSION_DATA.some((d) => d.names.includes(c.name));
+            });
+
+            if (!stillCompleted) {
+                this.awaitingTabUpdate = false;
+            } else if (this.lastCompletedCommissionName) {
+                const sameNameComm = this.commissions.find((c) => c.name === this.lastCompletedCommissionName);
+                if (!sameNameComm || sameNameComm.progress < 1) {
+                    this.awaitingTabUpdate = false;
+                }
+            }
+        }
+    }
+}
+
+new CommissionMacro();

--- a/GlaciteCommissionMacro.js
+++ b/GlaciteCommissionMacro.js
@@ -1,0 +1,533 @@
+import { isDeveloperModeEnabled } from '../../utils/DeveloperModeState';
+import { OverlayManager } from '../../gui/OverlayUtils';
+import { CommissionClaimer } from '../../utils/CommissionUtils';
+import { MacroState } from '../../utils/MacroState';
+import { MiningUtils } from '../../utils/MiningUtils';
+import { ModuleBase } from '../../utils/ModuleBase';
+import { finiteNumber } from '../../utils/NumberUtils';
+import { EtherwarpPathfinder } from '../../utils/pathfinder/EtherwarpPathfinder';
+import Pathfinder from '../../utils/pathfinder/PathFinder';
+import { Guis } from '../../utils/player/Inventory';
+import { manager } from '../../utils/SkyblockEvents';
+import { TabListUtils } from '../../utils/TabListUtils';
+import { Mouse } from '../../utils/Ungrab';
+import { MiningBot } from './MiningBot';
+import { tunnelsMiner } from './TunnelsMiner';
+import { Utils } from '../../utils/Utils';
+
+const STATES = {
+    IDLE: 'Idle',
+    CHOOSING: 'Choosing Commission',
+    MINING: 'Mining',
+    CLAIMING: 'Claiming Rewards',
+    WAITING_GUI_CLOSE: 'Closing GUI',
+    WAITING_COLD: 'Waiting for Cold',
+};
+
+const SUPPORTED_ORES = ['glacite', 'umber', 'tungsten', 'peridot', 'aquamarine', 'onyx', 'citrine'];
+const EMISSARY_LOCATION = [2, 121, 237];
+const TRAVEL_MODES = ['Walk', 'Etherwarp'];
+
+class GlaciteCommissionMacro extends ModuleBase {
+    constructor() {
+        super({
+            name: 'Glacite Commission Macro',
+            subcategory: 'Mining',
+            developerMode: true,
+            description: 'Completes Glacite mining commissions with Tunnels Miner',
+            tooltip: 'Reads Glacite commissions from tab, mines required tunnel ores, and claims with pigeon or emissary.',
+            theme: '#88d7ff',
+            autoDisableOnWorldUnload: false,
+            isMacro: true,
+        });
+
+        this.bindToggleKey();
+
+        this.currentState = STATES.IDLE;
+        this.travelMode = TRAVEL_MODES[0];
+        this.coldThreshold = 20;
+        this.pauseTicks = 0;
+        this.rodSwapEnabled = false;
+        this.commissions = [];
+        this.currentCommission = null;
+        this.activeOreTypes = [];
+        this.awaitingTabUpdate = false;
+        this.ignoreTabUpdatesUntil = 0;
+        this.lastCommissionSyncSource = null;
+        this.lastCompletedCommissionName = null;
+        this.pendingMiningStart = false;
+        this.lastTunnelRestartAt = 0;
+        this.noSupportedMessageAt = 0;
+        this.drill = null;
+        this.commissionClaimer = new CommissionClaimer({
+            getLocations: () => [EMISSARY_LOCATION],
+            isClaiming: () => this.enabled && this.currentState === STATES.CLAIMING,
+            delay: (ticks) => this.delay(ticks),
+            onClaimsExhausted: (container) => {
+                this.updateCommissionsFromGui(container);
+                Guis.closeInv();
+                this.setState(STATES.WAITING_GUI_CLOSE);
+            },
+            onPathFailed: () => {
+                this.message('&cFailed to reach Glacite emissary.');
+                this.setState(STATES.CHOOSING);
+                this.delay(20);
+            },
+            useEtherwarp: () => this.travelMode === 'Etherwarp',
+            rodSlot: () => this.getRodSwapSlot(),
+        });
+
+        this.addMultiToggle(
+            'Travel Mode',
+            TRAVEL_MODES,
+            true,
+            (selected) => {
+                const enabled = Array.isArray(selected) ? selected.find((item) => item.enabled) : null;
+                this.travelMode = enabled?.name || TRAVEL_MODES[0];
+            },
+            'How the macro travels to tunnel veins.',
+            TRAVEL_MODES[0]
+        );
+
+        this.addSlider('Cold Warp Threshold', 10, 90, this.coldThreshold, (value) => (this.coldThreshold = value));
+
+        this.addToggle(
+            'Rod Swap on Commission Claim',
+            (value) => {
+                this.rodSwapEnabled = value;
+            },
+            'Swaps to a rod in the hotbar and right-clicks the emissary to claim commissions.'
+        );
+
+        this.createOverlay(
+            [
+                {
+                    title: 'Status',
+                    data: {
+                        State: () => this.currentState,
+                        Commission: () => this.currentCommission?.name || 'None',
+                        Ores: () => this.getOreDisplay(),
+                    },
+                },
+                {
+                    title: 'Profits',
+                    data: {
+                        'Completed Commissions': () => this.getCompletedCommissions(),
+                        'Commissions/hr': () => this.getCommissionsPerHourDisplay(),
+                    },
+                },
+            ],
+            {
+                sessionTrackedValues: {
+                    commissionsCompleted: 0,
+                },
+            }
+        );
+
+        this.on('step', () => {
+            if (!this.enabled) return;
+            const newCommissions = TabListUtils.readCommissions();
+            this.updateCommissionsIfChanged(newCommissions);
+        }).setDelay(1);
+
+        this.on('tick', () => this.runLogic());
+
+        manager.subscribe('commissioncomplete', () => {
+            if (!this.enabled) return;
+            OverlayManager.incrementTrackedValue(this.oid, 'commissionsCompleted');
+            this.onCommissionComplete();
+        });
+
+        manager.subscribe('death', () => {
+            if (this.enabled) this.delayedReset(10);
+        });
+
+        manager.subscribe('serverchange', () => {
+            if (this.enabled) this.delayedReset(40);
+        });
+
+        this.on('worldUnload', () => {
+            if (this.enabled) this.delayedReset(40);
+        });
+    }
+
+    onEnable() {
+        this.message('&aEnabled');
+        Mouse.ungrab();
+        this.resetState();
+
+        const drills = MiningUtils.getDrills();
+        this.drill = drills.drill;
+
+        if (!this.drill) {
+            this.message('&cNo drill or pickaxe found in hotbar!');
+            this.toggle(false);
+            return;
+        }
+    }
+
+    onDisable() {
+        this.message('&cDisabled');
+        this.resetState();
+        Mouse.regrab();
+    }
+
+    resetState() {
+        this.currentState = STATES.IDLE;
+        this.pauseTicks = 0;
+        this.commissions = [];
+        this.currentCommission = null;
+        this.activeOreTypes = [];
+        this.awaitingTabUpdate = false;
+        this.ignoreTabUpdatesUntil = 0;
+        this.lastCommissionSyncSource = null;
+        this.lastCompletedCommissionName = null;
+        this.pendingMiningStart = false;
+        this.lastTunnelRestartAt = 0;
+        this.noSupportedMessageAt = 0;
+        this.areaCheckTime = null;
+        this.commissionClaimer.cancelNpcRotation();
+        this.stopTunnelMiner();
+        EtherwarpPathfinder.cancel(true);
+        Pathfinder.resetPath(true);
+    }
+
+    delayedReset(delay) {
+        const waitingForCold = this.currentState === STATES.WAITING_COLD;
+        this.resetState();
+        if (waitingForCold) this.setState(STATES.WAITING_COLD);
+        this.delay(delay);
+    }
+
+    runLogic() {
+        if (!this.enabled) return;
+        if (!Player.getPlayer()) return;
+
+        const cold = MiningUtils.getDebuff('cold');
+        if (this.currentState === STATES.WAITING_COLD) {
+            if (cold > 0) return;
+            this.setState(STATES.CHOOSING);
+            this.pauseTicks = 0;
+        } else if (cold > this.coldThreshold) {
+            this.stopTunnelMiner();
+            this.setState(STATES.WAITING_COLD);
+            this.message(`&eCold exceeded ${this.coldThreshold}, warping to camp...`);
+            ChatLib.command('warp camp');
+            return;
+        }
+
+        this.commissionClaimer.cancelNpcRotationIfPathing();
+
+        if (this.pauseTicks > 0) {
+            this.pauseTicks--;
+            return;
+        }
+
+        switch (this.currentState) {
+            case STATES.IDLE:
+                this.setState(STATES.CHOOSING);
+                break;
+            case STATES.CHOOSING:
+                this.handleChoosing();
+                break;
+            case STATES.MINING:
+                this.handleMining();
+                break;
+            case STATES.CLAIMING:
+                this.handleClaiming();
+                break;
+            case STATES.WAITING_GUI_CLOSE:
+                this.handleWaitingGuiClose();
+                break;
+            default:
+                break;
+        }
+    }
+
+    handleChoosing() {
+        const area = Utils.area();
+        const subarea = Utils.subArea();
+        const now = Date.now();
+        const validSubareas = ['Glacite Tunnels', 'Fossil Research Center', 'Dwarven Base Camp'];
+        if (area !== 'Dwarven Mines' || !validSubareas.includes(subarea)) {
+            if (!this.areaCheckTime) {
+                this.message('&eNot in the Glacite area, warping to camp...');
+                ChatLib.command('warp camp');
+                this.areaCheckTime = now;
+                return;
+            }
+            if (now - this.areaCheckTime > 10000) {
+                ChatLib.command('warp camp');
+                this.areaCheckTime = now;
+            }
+            return;
+        }
+        this.areaCheckTime = null;
+        const newCommissions = TabListUtils.readCommissions();
+        this.updateCommissionsIfChanged(newCommissions);
+
+        if (this.shouldWaitForLastCompleted()) return;
+        if (this.awaitingTabUpdate) return;
+
+        const completedCommission = this.findCompletedSupportedCommission();
+        if (completedCommission) {
+            this.currentCommission = completedCommission;
+            this.onCommissionComplete();
+            return;
+        }
+
+        const supportedCommissions = this.getSupportedActiveCommissions();
+        if (!supportedCommissions.length) {
+            this.stopTunnelMiner();
+            this.activeOreTypes = [];
+            this.currentCommission = null;
+            this.notifyNoSupportedCommissions();
+            this.delay(10);
+            return;
+        }
+
+        this.startMiningCommissions(supportedCommissions);
+    }
+
+    handleMining() {
+        const newCommissions = TabListUtils.readCommissions();
+        this.updateCommissionsIfChanged(newCommissions);
+
+        if (this.shouldWaitForLastCompleted()) return;
+        if (this.awaitingTabUpdate) return;
+
+        const completedCommission = this.findCompletedSupportedCommission();
+        if (completedCommission) {
+            this.currentCommission = completedCommission;
+            this.onCommissionComplete();
+            return;
+        }
+
+        const supportedCommissions = this.getSupportedActiveCommissions();
+        if (!supportedCommissions.length) {
+            this.stopTunnelMiner();
+            this.activeOreTypes = [];
+            this.currentCommission = null;
+            this.setState(STATES.CHOOSING);
+            return;
+        }
+
+        const neededOres = this.collectOreTypes(supportedCommissions);
+        if (!this.sameStringArrays(neededOres, this.activeOreTypes)) {
+            this.startMiningCommissions(supportedCommissions);
+            return;
+        }
+
+        const now = Date.now();
+        if (!Pathfinder.isPathing() && !EtherwarpPathfinder.isPathing() && !MiningBot.enabled && now - this.lastTunnelRestartAt >= 5000) {
+            tunnelsMiner.restart();
+            this.lastTunnelRestartAt = now;
+        }
+    }
+
+    handleClaiming() {
+        this.commissionClaimer.handle();
+    }
+
+    getRodSwapSlot() {
+        if (!this.rodSwapEnabled) return -1;
+        return Guis.findItemInHotbar('Rod');
+    }
+
+    handleWaitingGuiClose() {
+        if (Client.isInGui()) return;
+
+        if (this.pendingMiningStart && this.activeOreTypes.length > 0) {
+            this.pendingMiningStart = false;
+            this.beginTunnelMiner();
+            return;
+        }
+
+        this.setState(STATES.CHOOSING);
+    }
+
+    startMiningCommissions(commissions) {
+        const neededOres = this.collectOreTypes(commissions);
+        if (!neededOres.length) return;
+
+        this.currentCommission = commissions[0];
+        this.activeOreTypes = neededOres;
+        this.noSupportedMessageAt = 0;
+        if (Client.isInGui()) {
+            this.pendingMiningStart = true;
+            Guis.closeInv();
+            this.setState(STATES.WAITING_GUI_CLOSE);
+            return;
+        }
+
+        this.beginTunnelMiner();
+    }
+
+    beginTunnelMiner() {
+        tunnelsMiner.setSelectedOreNames(this.activeOreTypes);
+        tunnelsMiner.setTravelMode(this.travelMode);
+        if (tunnelsMiner.enabled) {
+            tunnelsMiner.restart();
+        } else {
+            tunnelsMiner.toggle(true, true);
+        }
+
+        this.lastTunnelRestartAt = Date.now();
+        this.setState(STATES.MINING);
+    }
+
+    stopTunnelMiner() {
+        if (tunnelsMiner.enabled) tunnelsMiner.toggle(false, true);
+        if (MiningBot.enabled) MiningBot.toggle(false, true);
+    }
+
+    onCommissionComplete() {
+        this.stopTunnelMiner();
+        Pathfinder.resetPath();
+        this.pendingMiningStart = false;
+        this.awaitingTabUpdate = true;
+        this.lastCompletedCommissionName = this.currentCommission?.name || null;
+        this.setState(STATES.CLAIMING);
+    }
+
+    updateCommissionsFromGui(container) {
+        const newCommissions = MiningUtils.readCommissionsFromGui(container, (name) => this.isSupportedCommissionName(name));
+        if (!newCommissions.length) return;
+
+        this.commissions = newCommissions;
+        this.awaitingTabUpdate = false;
+        this.lastCommissionSyncSource = 'GUI';
+        this.ignoreTabUpdatesUntil = Date.now() + 5000;
+
+        const currentName = this.currentCommission?.name;
+        const matching = currentName ? this.commissions.find((commission) => commission.name === currentName) : null;
+        if (!matching || matching.progress === 1) {
+            this.currentCommission = null;
+        }
+    }
+
+    findCompletedSupportedCommission() {
+        return this.commissions.find((commission) => commission.progress === 1 && this.isSupportedCommissionName(commission.name));
+    }
+
+    getSupportedActiveCommissions() {
+        return this.commissions.filter((commission) => commission.progress < 1 && this.isSupportedCommissionName(commission.name));
+    }
+
+    collectOreTypes(commissions) {
+        const oreSet = new Set();
+        commissions.forEach((commission) => {
+            this.extractOreTypesFromName(commission.name).forEach((ore) => oreSet.add(ore));
+        });
+        return SUPPORTED_ORES.filter((ore) => oreSet.has(ore));
+    }
+
+    extractOreTypesFromName(name) {
+        if (!name) return [];
+
+        const lowerName = String(name).toLowerCase();
+        if (/\d/.test(lowerName)) return [];
+        if (lowerName.includes('powder')) return [];
+
+        return SUPPORTED_ORES.filter((ore) => lowerName.includes(ore));
+    }
+
+    isSupportedCommissionName(name) {
+        return this.extractOreTypesFromName(name).length > 0;
+    }
+
+    shouldWaitForLastCompleted() {
+        if (!this.lastCompletedCommissionName) return false;
+
+        const staleCommission = this.commissions.find((commission) => commission.name === this.lastCompletedCommissionName && commission.progress > 0);
+        if (staleCommission?.progress === 1) return true;
+
+        this.lastCompletedCommissionName = null;
+        return false;
+    }
+
+    updateCommissionsIfChanged(newCommissions) {
+        if (this.commissionsEqual(this.commissions, newCommissions)) return;
+
+        const now = Date.now();
+        if (this.ignoreTabUpdatesUntil && now < this.ignoreTabUpdatesUntil && this.lastCommissionSyncSource === 'GUI') {
+            return;
+        }
+
+        if (this.ignoreTabUpdatesUntil && now < this.ignoreTabUpdatesUntil && this.lastCompletedCommissionName) {
+            const staleCompleted = newCommissions.find((commission) => commission.name === this.lastCompletedCommissionName && commission.progress === 1);
+            if (staleCompleted) return;
+            this.ignoreTabUpdatesUntil = 0;
+        } else if (this.ignoreTabUpdatesUntil && now >= this.ignoreTabUpdatesUntil) {
+            this.ignoreTabUpdatesUntil = 0;
+        }
+
+        this.commissions = newCommissions;
+        this.lastCommissionSyncSource = 'TAB';
+
+        if (!this.awaitingTabUpdate) return;
+
+        const stillCompleted = this.commissions.some((commission) => commission.progress === 1 && this.isSupportedCommissionName(commission.name));
+        if (!stillCompleted) {
+            this.awaitingTabUpdate = false;
+            return;
+        }
+
+        if (!this.lastCompletedCommissionName) return;
+
+        const sameNameCommission = this.commissions.find((commission) => commission.name === this.lastCompletedCommissionName);
+        if (!sameNameCommission || sameNameCommission.progress < 1) {
+            this.awaitingTabUpdate = false;
+        }
+    }
+
+    commissionsEqual(a, b) {
+        if (a === b) return true;
+        if (!Array.isArray(a) || !Array.isArray(b)) return false;
+        return a.length === b.length && a.every((left, i) => left?.name === b[i]?.name && left?.progress === b[i]?.progress);
+    }
+
+    sameStringArrays(left, right) {
+        if (left === right) return true;
+        if (!Array.isArray(left) || !Array.isArray(right)) return false;
+        return left.length === right.length && left.every((value, i) => value === right[i]);
+    }
+
+    notifyNoSupportedCommissions() {
+        const now = Date.now();
+        if (now - this.noSupportedMessageAt < 5000) return;
+
+        this.noSupportedMessageAt = now;
+        this.message('&eNo supported Glacite mining commissions detected.');
+    }
+
+    getOreDisplay() {
+        if (!this.activeOreTypes.length) return 'None';
+        return this.activeOreTypes.map((ore) => `${ore.charAt(0).toUpperCase()}${ore.slice(1)}`).join(', ');
+    }
+
+    getCompletedCommissions() {
+        return OverlayManager.getTrackedValue(this.oid, 'commissionsCompleted', 0);
+    }
+
+    getCommissionsPerHourDisplay() {
+        const elapsedMs = MacroState.getModuleElapsedMs(this.name);
+        if (elapsedMs <= 0) return '0.00';
+
+        const hours = elapsedMs / 3600000;
+        const rate = this.getCompletedCommissions() / hours;
+        if (!Number.isFinite(rate)) return '0.00';
+
+        return rate.toFixed(2);
+    }
+
+    delay(ticks) {
+        this.pauseTicks = Math.max(0, Math.floor(finiteNumber(ticks)));
+    }
+
+    setState(newState) {
+        if (this.currentState !== newState) this.currentState = newState;
+    }
+}
+
+if (isDeveloperModeEnabled()) new GlaciteCommissionMacro();

--- a/failsafes/AlertUtils.js
+++ b/failsafes/AlertUtils.js
@@ -1,6 +1,7 @@
 import { drawRect, drawText } from '../gui/Utils';
 import { Chat } from '../utils/Chat';
 import { File, globalAssetsDir } from '../utils/Constants';
+import { Notifications } from '../utils/Notifications';
 import { Utils } from '../utils/Utils';
 import FailsafeUtils from './FailsafeUtils';
 
@@ -22,6 +23,9 @@ class AlertUtilsClass {
         this.gainControl = null;
         this.savedSound = null;
         this.isAlerting = false;
+        this.failsafeVolume = 100;
+        this.customFailsafeSound = '';
+        this.grabWindowOnCheck = false;
 
         this.cancelKeyBind = null;
         this.cancelKey = null;
@@ -46,8 +50,10 @@ class AlertUtilsClass {
         Chat.messageFailsafe(`Press &c&l${this.cancelKey}&r &fto disable the reaction`);
 
         this.isAlerting = true;
+        this._refreshSettings();
         this.playSound();
-        this._grabWindowOnFailsafe();
+        this.sendDesktopAlert();
+        if (this.grabWindowOnCheck) this._grabWindowOnFailsafe();
 
         const line1 = 'V5 BELIEVES YOU HAVE BEEN MACRO CHECKED!';
         const key = this.cancelKey;
@@ -121,8 +127,25 @@ class AlertUtilsClass {
      */
     playSound() {
         if (!FailsafeUtils.getFailsafeSettings('Play sound on check').playSoundOnCheck) return;
-        const currentSound = failsafeSound;
+        this._playCurrentSound();
+    }
+
+    /**
+     * Plays the currently selected failsafe sound, ignoring the sound toggle
+     */
+    previewAlert() {
+        this._refreshSettings();
+        this._playCurrentSound();
+        Chat.messageFailsafe(`&aPreviewing failsafe sound at ${Math.max(0, Math.min(100, this.failsafeVolume))}% volume.`);
+    }
+
+    /**
+     * Loads and plays the current sound at the configured volume
+     */
+    _playCurrentSound() {
+        const currentSound = this._resolveSoundName();
         if (!this.clip || this.savedSound !== currentSound) this._loadsoundFile();
+        this._applyVolume();
 
         if (this.clip) {
             this.clip.stop();
@@ -138,8 +161,67 @@ class AlertUtilsClass {
         if (this.clip && this.clip.isRunning()) this.clip.stop();
     }
 
+    /**
+     * Sends a native desktop notification if the player has the setting toggled
+     */
+    sendDesktopAlert() {
+        try {
+            if (!FailsafeUtils.getFailsafeSettings('Desktop Notification on Check').desktopNotificationOnCheck) return;
+            Notifications.sendAlert('V5 believes you have been macro checked!');
+        } catch (e) {
+            console.error('V5 Caught error' + e + e.stack);
+        }
+    }
+
     setFailsafeSound(fileName) {
         failsafeSound = fileName;
+    }
+
+    setFailsafeVolume(volume) {
+        this.failsafeVolume = volume;
+        this._applyVolume();
+    }
+
+    setCustomFailsafeSound(value) {
+        this.customFailsafeSound = typeof value === 'string' ? value.trim() : '';
+        this.savedSound = null;
+    }
+
+    /**
+     * Pulls the latest sound related settings from the failsafe config
+     */
+    _refreshSettings() {
+        try {
+            const settings = FailsafeUtils.getFailsafeSettings('Failsafe Actions');
+            this.failsafeVolume = typeof settings.failsafeVolume === 'number' ? settings.failsafeVolume : 100;
+            this.customFailsafeSound = typeof settings.customFailsafeSound === 'string' ? settings.customFailsafeSound.trim() : '';
+            this.grabWindowOnCheck = !!settings.grabWindowOnCheck;
+        } catch (e) {
+            console.error('V5 Caught error' + e + e.stack);
+        }
+    }
+
+    /**
+     * Resolves the sound to use, preferring a custom sound if one is set
+     */
+    _resolveSoundName() {
+        if (this.customFailsafeSound) return this.customFailsafeSound;
+        return !failsafeSound || failsafeSound.includes('undefined') ? 'Tave Check.wav' : failsafeSound;
+    }
+
+    /**
+     * Applies the configured volume to the current gain control
+     */
+    _applyVolume() {
+        try {
+            if (!this.gainControl) return;
+            const volume = Math.max(0, Math.min(100, Number(this.failsafeVolume) || 100)) / 100;
+            const min = this.gainControl.getMinimum();
+            const max = this.gainControl.getMaximum();
+            this.gainControl.setValue(min + (max - min) * volume);
+        } catch (e) {
+            console.error('V5 Caught error' + e + e.stack);
+        }
     }
 
     /**
@@ -148,10 +230,11 @@ class AlertUtilsClass {
     _loadsoundFile() {
         this._closeSound();
 
-        const currentSound = failsafeSound;
-        this.savedSound = !currentSound || currentSound.includes('undefined') ? 'Tave Check.wav' : currentSound;
+        const currentSound = this._resolveSoundName();
+        this.savedSound = currentSound;
 
-        this.soundFile = new File(globalAssetsDir, `failsafes/sounds/${this.savedSound}`);
+        const hasSeparator = currentSound.includes('/') || currentSound.includes('\\');
+        this.soundFile = hasSeparator ? new File(currentSound) : new File(globalAssetsDir, `failsafes/sounds/${currentSound}`);
         if (!this.soundFile.exists()) return;
 
         try {
@@ -161,6 +244,7 @@ class AlertUtilsClass {
             if (this.clip.isControlSupported(FloatControl.Type.MASTER_GAIN)) {
                 this.gainControl = this.clip.getControl(FloatControl.Type.MASTER_GAIN);
             }
+            this._applyVolume();
         } catch (e) {
             this._closeSound();
             console.error('V5 Caught error' + e + e.stack);

--- a/failsafes/FailsafeUtils.js
+++ b/failsafes/FailsafeUtils.js
@@ -7,6 +7,10 @@ const DEFAULT_FAILSAFE_SETTINGS = {
     playerProximityDistance: 3,
     pingOnCheck: 'Ping',
     playSoundOnCheck: true,
+    desktopNotificationOnCheck: true,
+    grabWindowOnCheck: false,
+    failsafeVolume: 100,
+    customFailsafeSound: '',
 };
 
 class FailsafeUtils {
@@ -69,12 +73,25 @@ class FailsafeUtils {
             pingOnCheckValue = pingConfig ?? DEFAULT_FAILSAFE_SETTINGS.pingOnCheck;
         }
 
+        const actionsConfig = failsafesConfig['Failsafe Actions'];
+        let desktopNotificationOnCheck = failsafesConfig['Desktop Notification on Check'] ?? DEFAULT_FAILSAFE_SETTINGS.desktopNotificationOnCheck;
+        let grabWindowOnCheck = DEFAULT_FAILSAFE_SETTINGS.grabWindowOnCheck;
+        if (Array.isArray(actionsConfig)) {
+            const enabledActions = actionsConfig.filter((option) => option?.enabled).map((option) => option?.name);
+            desktopNotificationOnCheck = enabledActions.includes('Desktop Alerts');
+            grabWindowOnCheck = enabledActions.includes('Grab Game Window');
+        }
+
         const normalized = {
             enabledMap,
             rawEnabledList: enabledList,
             reactionInput: failsafesConfig['Failsafe Detection Delay (ms)'] ?? DEFAULT_FAILSAFE_SETTINGS.FailsafeReactionTime,
             playerProximityDistance: failsafesConfig['Player Proximity Distance'] ?? DEFAULT_FAILSAFE_SETTINGS.playerProximityDistance,
             playSoundOnCheck: failsafesConfig['Play sound on check'] ?? DEFAULT_FAILSAFE_SETTINGS.playSoundOnCheck,
+            desktopNotificationOnCheck,
+            grabWindowOnCheck,
+            failsafeVolume: failsafesConfig['Failsafe Sound Volume'] ?? DEFAULT_FAILSAFE_SETTINGS.failsafeVolume,
+            customFailsafeSound: failsafesConfig['Custom Failsafe Sound'] ?? DEFAULT_FAILSAFE_SETTINGS.customFailsafeSound,
             pingOnCheck: pingOnCheckValue,
         };
 
@@ -113,6 +130,10 @@ class FailsafeUtils {
             playerProximityDistance: normalized.playerProximityDistance,
             pingOnCheck: normalized.pingOnCheck,
             playSoundOnCheck: normalized.playSoundOnCheck,
+            desktopNotificationOnCheck: normalized.desktopNotificationOnCheck,
+            grabWindowOnCheck: normalized.grabWindowOnCheck,
+            failsafeVolume: normalized.failsafeVolume,
+            customFailsafeSound: normalized.customFailsafeSound,
         };
     }
 

--- a/gui/GuiSave.js
+++ b/gui/GuiSave.js
@@ -79,10 +79,10 @@ export const saveSettings = () => {
     Utils.writeConfigFile('config.json', settings);
 };
 
-export const applySettings = () => {
+export const applySettings = (applyModuleStates = true) => {
     Categories.categories.forEach((category) => {
         getCategoryItems(category).forEach((item) => {
-            if (category.name === 'Modules') {
+            if (applyModuleStates && category.name === 'Modules') {
                 const enabled = getSetting(item.title, 'Enabled');
                 applyModuleEnabled(item.title, enabled);
             }
@@ -92,7 +92,7 @@ export const applySettings = () => {
             });
         });
 
-        if (category.directComponents) {
+        if (applyModuleStates && category.directComponents) {
             category.directComponents.forEach((component) => {
                 const parentName = getDirectComponentParentName(category, component);
                 triggerComponentCallback(parentName, component);
@@ -123,7 +123,7 @@ function triggerComponentCallback(parentName, component) {
     }
 }
 
-export const loadSettings = () => {
+export const loadSettings = (applyModuleStates = true) => {
     const settings = Utils.getConfigFile('config.json');
 
     if (!settings || Object.keys(settings).length === 0) {
@@ -155,7 +155,7 @@ export const loadSettings = () => {
 
         buildSettingsMapFromComponents();
         mergeSavedModuleEnabledStates(settings);
-        applySettings();
+        applySettings(applyModuleStates);
     } catch (e) {
         Chat.message(`Error loading settings: ${e}`);
         console.error('V5 Caught error' + e + e.stack);

--- a/gui/MacroToggleGui.js
+++ b/gui/MacroToggleGui.js
@@ -101,7 +101,7 @@ export const macroToggleGui = {
         GuiState.macroToggleOpen = true;
         GuiState.isOpening = true;
         GuiState.openStartTime = Date.now();
-        loadSettings();
+        loadSettings(false);
         GuiState.myGui.open();
     },
 

--- a/gui/OverlayUtils.js
+++ b/gui/OverlayUtils.js
@@ -998,7 +998,7 @@ class OverlayUtils {
 
     closePositionsGUI() {
         GuiState.isOpening = true;
-        loadSettings();
+        loadSettings(false);
         GuiState.myGui.open();
         this.drawingGUI = false;
     }

--- a/gui/categories/CategorySystem.js
+++ b/gui/categories/CategorySystem.js
@@ -240,9 +240,9 @@ export const Categories = {
         return Categories.attachSettingsComponent(new ColorPicker(title, 0, 0, defaultColor, callback), sectionName, categoryName, description);
     },
 
-    addSettingsTextInput(title, defaultValue, callback = null, description = null, sectionName = null, categoryName = 'Settings') {
+    addSettingsTextInput(title, defaultValue, callback = null, description = null, sectionName = null, onBoxClick = null, categoryName = 'Settings') {
         return Categories.attachSettingsComponent(
-            new TextInput(title, 0, 0, undefined, undefined, defaultValue, callback),
+            new TextInput(title, 0, 0, undefined, undefined, defaultValue, callback, onBoxClick),
             sectionName,
             categoryName,
             description

--- a/gui/components/TextInput.js
+++ b/gui/components/TextInput.js
@@ -20,7 +20,7 @@ let activeTextInput = null;
 const allTextInputs = [];
 
 export class TextInput {
-    constructor(title, x, y, width, height, defaultValue = '', callback = null) {
+    constructor(title, x, y, width, height, defaultValue = '', callback = null, onBoxClick = null) {
         this.title = title;
         this.x = x;
         this.y = y;
@@ -28,6 +28,7 @@ export class TextInput {
         this.height = height;
         this.value = defaultValue;
         this.callback = callback;
+        this.onBoxClick = onBoxClick;
 
         this.isTyping = false;
         this.text = String(defaultValue);
@@ -185,6 +186,11 @@ export class TextInput {
 
     handleClick(mouseX, mouseY) {
         if (isInside(mouseX, mouseY, this.inputRect)) {
+            if (this.onBoxClick) {
+                if (this.isTyping) this.handleInputFinish();
+                this.onBoxClick(this);
+                return true;
+            }
             if (activeTextInput && activeTextInput !== this) {
                 activeTextInput.handleInputFinish({ playSound: false });
             }

--- a/gui/core/GuiEvents.js
+++ b/gui/core/GuiEvents.js
@@ -71,7 +71,7 @@ const handleGuiClosed = () => {
 export const openGui = () => {
     GuiState.isOpening = true;
     GuiState.openStartTime = Date.now();
-    loadSettings();
+    loadSettings(false);
     categoryManager?.invalidateLayoutCache();
     categoryManager?.invalidateContentHeightCache();
     GuiState.myGui.open();

--- a/loader.js
+++ b/loader.js
@@ -1,40 +1,71 @@
-Config.setAutoUpdateModules(false);
-Config.setOpenConsoleOnError(true);
+/* MINING */
+import './mining/CommissionMacro';
+import './mining/ExcavatorMacro';
+import './mining/GlaciteCommissionMacro';
+import './mining/JasperDrillExploit';
+import './mining/LobbyHopper';
+import './foraging/MudwormMacro';
+import './foraging/LushLilacEtherwarpNuker';
+import './mining/Nuker';
+import './mining/OreMacro';
+import './mining/PinglessMining';
+import './mining/GlowingMushroomMacro';
+import './mining/TunnelsMiner';
 
-/* COMMANDS */
-import { registerV5Commands } from './utils/V5Commands';
+/* FORAGING */
+import './foraging/AutoHarp';
+import './foraging/HideonLeafESP';
+import './foraging/HuntingHelpers';
 
-/* GUI */
-import './gui/GUI';
+/* FARMING */
+import './farming/CocoaBeansMacro';
+import './farming/ADRotatingMelonMacro';
+import './farming/SShapeCropMacro';
+import './farming/WSRowMacros';
 
-/* CORE */
-import './utils/Config';
-import './utils/backend/WebSocket';
-import { ServerboundCommandSuggestionPacket } from './utils/Packets';
+/* VISUALS */
+import './visuals/BlockVisual';
+import './visuals/ESP';
+import './visuals/GIF';
+import './visuals/HUD';
+import './visuals/MobHider';
+import './visuals/MusicOverlay';
+import './visuals/PestESP';
+import './visuals/ProfileHider';
+import './visuals/RatESP';
+import './visuals/StructureESP';
+import './visuals/GlowingMushroomESP';
+import './visuals/PiP';
 
-register('packetSent', (packet, event) => {
-    if (packet.getCommand().toLowerCase().startsWith('/v5')) cancel(event);
-}).setFilteredClass(ServerboundCommandSuggestionPacket);
+/* SKILLS */
+import './skills/AutoExperiments';
+import './skills/ChocolateFactory';
+import './skills/FishingHelper';
+import './skills/FishOnMCMacro';
+import './skills/StridersurferMacro';
+import './skills/JerryBoxMacro';
+import './skills/MinionCollector';
+import './skills/RouteWalker';
+import './skills/WynnProfessionMacro';
 
-/* Utils */
-import { MacroState } from './utils/MacroState';
-import './modules/other/MacroScheduler';
-import './modules/other/MacroControllers';
-import './modules/other/DiscordIntegration';
-import './utils/pathfinder/PathFinder';
-import './utils/pathfinder/EtherwarpPathfinder';
-import './utils/Misc';
-import './utils/SkyblockItemUtil';
-import './failsafes/FailsafeManager';
-import './utils/SkyblockEvents';
-
-/* Modules */
-import './modules/loader';
-import './utils/UserScripts';
-
-import { loadSettings } from './gui/GuiSave';
-registerV5Commands();
-MacroState.setupLastMacroToggleKey();
-loadSettings();
-
-import './utils/DeveloperModeState';
+/* OTHER */
+import './other/AutoBeg';
+import './other/AutoConversation';
+import './other/AuctionHelper';
+import './other/BeachBaller';
+import './other/CancelInteract';
+import './other/ChatQOL';
+import './other/DiscordRPC';
+import './other/Failsafes';
+import './other/Freecam';
+import './other/Freelook';
+import './other/InventoryWalk';
+import './other/LeftClickEtherwarp';
+import './other/RatProtection';
+import './other/VoidgloomHelper';
+import './other/AutoCombine';
+import './other/AutoFusionRepeat';
+import './other/SunGeckoMacro';
+import './other/RatMacro';
+import './other/PeltMacro';
+import './other/PeltQOL';

--- a/modules/combat/CombatBot.js
+++ b/modules/combat/CombatBot.js
@@ -98,6 +98,27 @@ class Combat extends ModuleBase {
             'Attacks per second'
         );
 
+        this.targetName = '';
+        this.skyblockName = '';
+
+        this.addTextInput(
+            'Target Name',
+            '',
+            (value) => {
+                this.targetName = value;
+            },
+            'Targets mobs whose entity display name contains this text. Separate multiple names with a comma or |.'
+        );
+
+        this.addTextInput(
+            'Skyblock Name',
+            '',
+            (value) => {
+                this.skyblockName = value;
+            },
+            'Targets mobs whose internal/Skyblock name contains this text. Separate multiple names with a comma or |.'
+        );
+
         this.createOverlay([
             {
                 title: 'Status',
@@ -785,6 +806,9 @@ class Combat extends ModuleBase {
             return [];
         }
 
+        const targetNames = this.splitNames(this.targetName);
+        const skyblockNames = this.splitNames(this.skyblockName);
+
         const mobs = [];
 
         World.getAllEntities().forEach((entity) => {
@@ -792,10 +816,24 @@ class Combat extends ModuleBase {
                 const nameObj = entity.getName();
                 if (!nameObj) return;
 
-                const name = ChatLib.removeFormatting(String(nameObj?.getString?.() ?? nameObj)).toLowerCase();
+                const displayName = ChatLib.removeFormatting(String(nameObj?.getString?.() ?? nameObj)).toLowerCase();
                 const uuid = entity.getUUID();
                 if (whitelist && whitelist.has(uuid)) return;
-                if (!config.names.some((mobName) => name.includes(mobName.toLowerCase()))) return;
+
+                const matchesConfig = config.names.some((mobName) => displayName.includes(mobName.toLowerCase()));
+
+                let matchesTargetName = false;
+                let matchesSkyblockName = false;
+                if (targetNames.length > 0) {
+                    matchesTargetName = targetNames.some((name) => displayName.includes(name));
+                }
+                if (skyblockNames.length > 0) {
+                    const rawName = String(nameObj?.getString?.() ?? nameObj ?? '').toLowerCase();
+                    const typeName = String(entity.getType?.()?.getRegistryName?.() ?? '').toLowerCase();
+                    matchesSkyblockName = skyblockNames.some((name) => rawName.includes(name) || typeName.includes(name));
+                }
+
+                if (!matchesConfig && !matchesTargetName && !matchesSkyblockName) return;
                 if (entity.isSpectator?.() || entity.isInvisible() || entity.isDead()) return;
                 if (!this.isVisibleOrRecent(entity, config.checkVisibility)) return;
 
@@ -811,6 +849,14 @@ class Combat extends ModuleBase {
         });
 
         return mobs;
+    }
+
+    splitNames(input) {
+        if (typeof input !== 'string' || !input.trim()) return [];
+        return input
+            .split(/[,|]/)
+            .map((name) => name.trim().toLowerCase())
+            .filter((name) => name.length > 0);
     }
 
     onEnable() {

--- a/modules/loader.js
+++ b/modules/loader.js
@@ -35,6 +35,7 @@ import './visuals/ProfileHider';
 import './visuals/RatESP';
 import './visuals/StructureESP';
 import './visuals/GlowingMushroomESP';
+import './visuals/PiP';
 
 /* SKILLS */
 import './skills/AutoExperiments';

--- a/modules/mining/CommissionMacro.js
+++ b/modules/mining/CommissionMacro.js
@@ -49,6 +49,7 @@ class CommissionMacro extends ModuleBase {
         this.goblinWeaponSlot = 1;
         this.emissariesUnlocked = true;
         this.pauseTicks = 0;
+        this.rodSwapEnabled = false;
         this.pathingAvoidanceBreachAt = null;
         this.lastAvoidanceRepathAt = 0;
         this.currentPathWaypoint = null;
@@ -87,6 +88,8 @@ class CommissionMacro extends ModuleBase {
             onPathFailed: () => this.setState(STATES.CHOOSING),
             canInteract: () => !this.emissariesUnlocked || this.checkEmissaryUnlocked(),
             useEtherwarp: () => this.travelMode === 'Etherwarp',
+            rodSlot: () => this.getRodSwapSlot(),
+            getToolSlot: () => (this.drill ? this.drill.slot : -1),
         });
 
         this.addMultiToggle(
@@ -181,6 +184,14 @@ class CommissionMacro extends ModuleBase {
                 this.goblinWeaponSlot = value;
             },
             'Hotbar slot with weapon for Goblin Slayer (1-8)'
+        );
+
+        this.addToggle(
+            'Rod Swap on Commission Claim',
+            (value) => {
+                this.rodSwapEnabled = value;
+            },
+            'Swaps to a rod in the hotbar and right-clicks the emissary to claim commissions.'
         );
     }
 
@@ -634,6 +645,11 @@ class CommissionMacro extends ModuleBase {
 
     handleClaiming() {
         this.commissionClaimer.handle();
+    }
+
+    getRodSwapSlot() {
+        if (!this.rodSwapEnabled) return -1;
+        return Guis.findItemInHotbar('Rod');
     }
 
     ensureDrillEquippedForEmissaryClaim() {

--- a/modules/mining/ExcavatorMacro.js
+++ b/modules/mining/ExcavatorMacro.js
@@ -22,6 +22,8 @@ class ExcavatorMacro extends ModuleBase {
 
         this.NODELAY = false;
         this.TICKDELAY = 0;
+        this.PLACEDELAY = 0;
+        this.REOPENDELAY = 0;
 
         this.addToggle(
             'No delay',
@@ -32,14 +34,36 @@ class ExcavatorMacro extends ModuleBase {
         );
 
         this.addSlider(
-            'Tick delay',
+            'Click delay',
             1,
             10,
             5,
             (v) => {
                 this.TICKDELAY = v;
             },
-            'Amount of ticks until the player can click again'
+            'Amount of ticks between clicks'
+        );
+
+        this.addSlider(
+            'Item placement delay',
+            1,
+            10,
+            3,
+            (v) => {
+                this.PLACEDELAY = v;
+            },
+            'Amount of ticks to wait after placing an item'
+        );
+
+        this.addSlider(
+            'Reopen delay',
+            1,
+            20,
+            6,
+            (v) => {
+                this.REOPENDELAY = v;
+            },
+            'Amount of ticks to wait before reopening the excavator'
         );
 
         this.STATES = {
@@ -53,6 +77,8 @@ class ExcavatorMacro extends ModuleBase {
 
         this.inExcavator = false;
         this.tickCount = this.TICKDELAY || 0;
+        this.placeTickCount = 0;
+        this.reopenTickCount = 0;
         this.blacklistedSlots = new Map();
         this.warpCooldownTicks = 0;
 
@@ -83,6 +109,7 @@ class ExcavatorMacro extends ModuleBase {
             switch (this.state) {
                 case this.STATES.OPENING:
                     if (Player.lookingAt() instanceof Entity && !this.inExcavator) {
+                        if (!this.reopenDelay()) return;
                         Client.rightClick();
                         this.state = this.STATES.SETUP;
                     } else {
@@ -101,6 +128,11 @@ class ExcavatorMacro extends ModuleBase {
                     break;
                 case this.STATES.EXCAVATING:
                     if (Guis.guiName() !== 'Fossil Excavator') return;
+
+                    if (this.placeTickCount > 0) {
+                        this.placeTickCount--;
+                        return;
+                    }
 
                     const brownSlots = [];
                     const container = Player.getContainer();
@@ -125,6 +157,7 @@ class ExcavatorMacro extends ModuleBase {
                         if (slot?.type?.getRegistryName()?.includes('lime_stained')) {
                             if (!this.clickDelay()) return;
                             Guis.clickSlot(i);
+                            this.placeDelay();
                             this.blacklistSlot(i, 10);
                             return;
                         }
@@ -139,6 +172,7 @@ class ExcavatorMacro extends ModuleBase {
                         if (!this.clickDelay()) return;
 
                         Guis.clickSlot(randomBrownSlot);
+                        this.placeDelay();
                         this.blacklistSlot(randomBrownSlot, 10);
                         return;
                     }
@@ -212,6 +246,22 @@ class ExcavatorMacro extends ModuleBase {
         }
 
         this.tickCount = this.TICKDELAY;
+        return true;
+    }
+
+    placeDelay() {
+        this.placeTickCount = this.PLACEDELAY || 0;
+    }
+
+    reopenDelay() {
+        if (this.NODELAY) return true;
+
+        if (this.reopenTickCount > 0) {
+            this.reopenTickCount--;
+            return false;
+        }
+
+        this.reopenTickCount = this.REOPENDELAY;
         return true;
     }
 

--- a/modules/mining/GlaciteCommissionMacro.js
+++ b/modules/mining/GlaciteCommissionMacro.js
@@ -47,6 +47,7 @@ class GlaciteCommissionMacro extends ModuleBase {
         this.travelMode = TRAVEL_MODES[0];
         this.coldThreshold = 20;
         this.pauseTicks = 0;
+        this.rodSwapEnabled = false;
         this.commissions = [];
         this.currentCommission = null;
         this.activeOreTypes = [];
@@ -74,6 +75,8 @@ class GlaciteCommissionMacro extends ModuleBase {
                 this.delay(20);
             },
             useEtherwarp: () => this.travelMode === 'Etherwarp',
+            rodSlot: () => this.getRodSwapSlot(),
+            getToolSlot: () => (this.drill ? this.drill.slot : -1),
         });
 
         this.addMultiToggle(
@@ -89,6 +92,14 @@ class GlaciteCommissionMacro extends ModuleBase {
         );
 
         this.addSlider('Cold Warp Threshold', 10, 90, this.coldThreshold, (value) => (this.coldThreshold = value));
+
+        this.addToggle(
+            'Rod Swap on Commission Claim',
+            (value) => {
+                this.rodSwapEnabled = value;
+            },
+            'Swaps to a rod in the hotbar and right-clicks the emissary to claim commissions.'
+        );
 
         this.createOverlay(
             [
@@ -316,6 +327,11 @@ class GlaciteCommissionMacro extends ModuleBase {
 
     handleClaiming() {
         this.commissionClaimer.handle();
+    }
+
+    getRodSwapSlot() {
+        if (!this.rodSwapEnabled) return -1;
+        return Guis.findItemInHotbar('Rod');
     }
 
     handleWaitingGuiClose() {

--- a/modules/mining/LobbyHopper.js
+++ b/modules/mining/LobbyHopper.js
@@ -15,11 +15,19 @@ class LobbyHopper extends ModuleBase {
         this.maxDay = 0;
         this.said = false;
         this.cooldown = new Timer();
+        this.useNucleus = false;
         this.bindToggleKey();
 
         this.addSlider('Max Lobby Day', 0, 18, 5, (v) => {
             this.maxDay = v;
         });
+        this.addToggle(
+            'Warp to Nucleus Instead of Hollows',
+            (v) => {
+                this.useNucleus = v;
+            },
+            'Warps to the Glacite Nucleus instead of Crystal Hollows when a lobby is too old.'
+        );
 
         this.on('step', () => {
             if (!this.enabled) return;
@@ -29,7 +37,11 @@ class LobbyHopper extends ModuleBase {
 
             if (!isInCh) {
                 this.message('Not in Crystal Hollows, Warping.');
-                ChatLib.command('warp ch');
+                if (this.useNucleus) {
+                    ChatLib.command('warp nucleus');
+                } else {
+                    ChatLib.command('warp ch');
+                }
 
                 this.reset();
             } else {

--- a/modules/mining/MiningBot.js
+++ b/modules/mining/MiningBot.js
@@ -47,6 +47,7 @@ class Bot extends ModuleBase {
 
         this.PRIORITIZE_TITANIUM = true;
         this.PRIORITIZE_GRAY_MITHRIL = false;
+        this.PRIORITIZE_BLUE_WOOL = false;
         this.TICKGLIDE = true;
         this.FAKELOOK = false;
         this.MOVEMENT = false;
@@ -81,6 +82,10 @@ class Bot extends ModuleBase {
         this.lastUse = Date.now();
         this.ABILITY_COOLDOWN_MS = 200000;
         this._pendingAbilityActivation = false;
+        this.abilityRodSwapEnabled = false;
+        this._abilityStage = null;
+        this._abilityStageTicks = 0;
+        this._rodSlot = null;
         this.fakeLookModeName = 'Off';
         this.selectedTypeName = 'Mithril';
         this._renderPalette = {
@@ -213,7 +218,7 @@ class Bot extends ModuleBase {
     }
 
     updateMithrilCosts() {
-        const lightBlueCost = this.PRIORITIZE_GRAY_MITHRIL ? 20 : 3;
+        const lightBlueCost = this.PRIORITIZE_BLUE_WOOL ? 1 : this.PRIORITIZE_GRAY_MITHRIL ? 20 : 3;
         const prismarineCost = 10;
         const grayCost = this.PRIORITIZE_GRAY_MITHRIL ? 1 : 20;
 
@@ -255,10 +260,12 @@ class Bot extends ModuleBase {
 
         manager.subscribe('abilityready', () => {
             if (!this.enabled || this.refreshingMiningStats) return;
+            this._abilityStage = null;
+            this._abilityStageTicks = 0;
             this.resetTickCounters();
             this.abilityFromChat = true;
             this.state = this.STATES.ABILITY;
-            if (this.DEBUG_MODE) this.message(`&a[DEBUG] abilityready → state=ABILITY, abilityFromChat=true`);
+            if (this.DEBUG_MODE) this.message(`&a[DEBUG] abilityready �?state=ABILITY, abilityFromChat=true`);
         });
 
         manager.subscribe('abilityused', () => {
@@ -267,23 +274,27 @@ class Bot extends ModuleBase {
             this.abilityFromChat = false;
             this.lastUse = Date.now();
             this.resetTickCounters();
-            if (this.DEBUG_MODE) this.message(`&e[DEBUG] abilityused → abilityFromChat=false, lastUse=${this.lastUse}`);
+            if (this.DEBUG_MODE) this.message(`&e[DEBUG] abilityused �?abilityFromChat=false, lastUse=${this.lastUse}`);
         });
 
         manager.subscribe('abilitygone', () => {
             if (!this.enabled) return;
             this.speedBoost = false;
             this.abilityFromChat = false;
+            this._abilityStage = null;
+            this._abilityStageTicks = 0;
             this.lastUse = Date.now();
             this.resetTickCounters();
-            if (this.DEBUG_MODE) this.message(`&e[DEBUG] abilitygone → abilityFromChat=false, lastUse=${this.lastUse}`);
+            if (this.DEBUG_MODE) this.message(`&e[DEBUG] abilitygone �?abilityFromChat=false, lastUse=${this.lastUse}`);
         });
 
         manager.subscribe('abilitycooldown', () => {
             if (!this.enabled) return;
+            this._abilityStage = null;
+            this._abilityStageTicks = 0;
             this.lastUse = Date.now();
             this.state = this.STATES.MINING;
-            if (this.DEBUG_MODE) this.message(`&c[DEBUG] abilitycooldown → lastUse=${this.lastUse}, state=MINING`);
+            if (this.DEBUG_MODE) this.message(`&c[DEBUG] abilitycooldown �?lastUse=${this.lastUse}, state=MINING`);
         });
     }
 
@@ -337,6 +348,13 @@ class Bot extends ModuleBase {
             },
             'Reverses mithril block targeting costs to prioritise gray mithril.'
         );
+        this.addToggle(
+            'Prioritise Blue Wool',
+            (value) => {
+                this.setPrioritizeBlueWool(value);
+            },
+            'Reverses mithril block targeting costs to prioritise blue wool.'
+        );
         this.addMultiToggle(
             'Fakelook',
             ['Off', 'Queued'],
@@ -359,6 +377,13 @@ class Bot extends ModuleBase {
             },
             'Targets specified block type.',
             'Mithril'
+        );
+        this.addToggle(
+            'Ability Rod Swap',
+            (value) => {
+                this.abilityRodSwapEnabled = value;
+            },
+            'Swaps to a rod in the hotbar and right-clicks first, then releases the drill pickaxe ability, then returns to the drill and resumes mining.'
         );
         // this.addToggle(
         //     'Debug Mode',
@@ -384,6 +409,11 @@ class Bot extends ModuleBase {
 
     setPrioritizeGrayMithril(value) {
         this.PRIORITIZE_GRAY_MITHRIL = value;
+        this.updateMithrilCosts();
+    }
+
+    setPrioritizeBlueWool(value) {
+        this.PRIORITIZE_BLUE_WOOL = value;
         this.updateMithrilCosts();
     }
 
@@ -596,17 +626,18 @@ class Bot extends ModuleBase {
 
         if (this.DEBUG_MODE) {
             this.message(
-                `&7[DEBUG] handleAbilityState status="${abilityStatus}" chat=${this.abilityFromChat} lastUse=${this.lastUse} pending=${this._pendingAbilityActivation} handSwinging=${Player.getPlayer().handSwinging}`
+                `&7[DEBUG] handleAbilityState status="${abilityStatus}" chat=${this.abilityFromChat} lastUse=${this.lastUse} pending=${this._pendingAbilityActivation} stage=${this._abilityStage} handSwinging=${Player.getPlayer().handSwinging}`
             );
+        }
+
+        if (this._abilityStage) {
+            this._advanceAbilitySequence();
+            return;
         }
 
         if (this._pendingAbilityActivation) {
             this._pendingAbilityActivation = false;
-            Client.rightClick();
-            if (this.DEBUG_MODE) this.message(`&a[DEBUG] RIGHT-CLICKED status="${abilityStatus}"`);
-            this.lastUse = now;
-            this.abilityFromChat = false;
-            this.state = this.STATES.MINING;
+            this._startAbilitySequence();
             return;
         }
 
@@ -615,11 +646,76 @@ class Bot extends ModuleBase {
 
             Client.setKey('leftclick', false);
             this._pendingAbilityActivation = true;
-            if (this.DEBUG_MODE) this.message(`&e[DEBUG] Released left-click, will right-click next tick (swing=${Player.getPlayer().handSwinging})`);
+            if (this.DEBUG_MODE) this.message(`&e[DEBUG] Released left-click, starting ability sequence next tick (swing=${Player.getPlayer().handSwinging})`);
             return;
         }
 
         if (this.DEBUG_MODE) this.message(`&c[DEBUG] No condition met, going MINING`);
+        this.state = this.STATES.MINING;
+    }
+
+    _startAbilitySequence() {
+        if (this.abilityRodSwapEnabled) {
+            const rodSlot = Guis.findItemInHotbar('Rod');
+            if (rodSlot >= 0) {
+                this._rodSlot = rodSlot;
+                this._abilityStage = 'SWAP_TO_ROD';
+                this._abilityStageTicks = 2;
+                if (this.DEBUG_MODE) this.message(`&a[DEBUG] Swapping to rod first, then releasing drill ability (slot ${rodSlot})`);
+                return;
+            }
+        }
+
+        Client.rightClick();
+        this._finishAbilitySequence();
+    }
+
+    _advanceAbilitySequence() {
+        if (this._abilityStageTicks > 0) {
+            this._abilityStageTicks--;
+            return;
+        }
+
+        if (this._abilityStage === 'SWAP_TO_ROD') {
+            if (this._rodSlot !== null) Guis.setItemSlot(this._rodSlot);
+            this._abilityStage = 'ROD_CLICK';
+            this._abilityStageTicks = 3;
+            if (this.DEBUG_MODE) this.message(`&a[DEBUG] Swapped to rod, right-clicking in 3 ticks`);
+            return;
+        }
+
+        if (this._abilityStage === 'ROD_CLICK') {
+            Client.rightClick();
+            this._abilityStage = 'CAST_ABILITY';
+            this._abilityStageTicks = 2;
+            if (this.DEBUG_MODE) this.message(`&a[DEBUG] RIGHT-CLICKED rod, swapping to drill to release ability`);
+            return;
+        }
+
+        if (this._abilityStage === 'CAST_ABILITY') {
+            this.ensureDrillEquipped(this.drill);
+            this._abilityStage = 'ABILITY_CLICK';
+            this._abilityStageTicks = 2;
+            if (this.DEBUG_MODE) this.message(`&a[DEBUG] Drill equipped, releasing ability in 2 ticks`);
+            return;
+        }
+
+        if (this._abilityStage === 'ABILITY_CLICK') {
+            Client.rightClick();
+            if (this.DEBUG_MODE) this.message(`&a[DEBUG] Released drill ability`);
+            this._finishAbilitySequence();
+            return;
+        }
+
+        this._finishAbilitySequence();
+    }
+
+    _finishAbilitySequence() {
+        this._abilityStage = null;
+        this._abilityStageTicks = 0;
+        this._rodSlot = null;
+        this.lastUse = Date.now();
+        this.abilityFromChat = false;
         this.state = this.STATES.MINING;
     }
 
@@ -1444,6 +1540,9 @@ class Bot extends ModuleBase {
 
         this.state = this.STATES.WAITING;
         this._pendingAbilityActivation = false;
+        this._abilityStage = null;
+        this._abilityStageTicks = 0;
+        this._rodSlot = null;
         Client.stopMovement();
         Client.setKey('space', false);
         this.setSneak(false, true);

--- a/modules/other/Failsafes.js
+++ b/modules/other/Failsafes.js
@@ -110,6 +110,21 @@ class Failsafes extends ModuleBase {
             sectionName
         );
         this.addDirectMultiToggle(
+            'Failsafe Actions',
+            ['Desktop Alerts', 'Grab Game Window'],
+            false,
+            (value) => {
+                const enabled = Array.isArray(value)
+                    ? value.filter((opt) => opt && opt.name && opt.enabled).map((opt) => opt.name)
+                    : [];
+                this.desktopAlertsEnabled = enabled.includes('Desktop Alerts');
+                this.grabWindowEnabled = enabled.includes('Grab Game Window');
+            },
+            'Actions to perform when a failsafe triggers.',
+            ['Desktop Alerts'],
+            sectionName
+        );
+        this.addDirectMultiToggle(
             'Failsafe sound',
             this.getFilesInDir(),
             true,
@@ -127,11 +142,61 @@ class Failsafes extends ModuleBase {
             false,
             sectionName
         );
+        this.addDirectSlider(
+            'Failsafe Sound Volume',
+            0,
+            100,
+            100,
+            (value) => {
+                AlertUtils.setFailsafeVolume(value);
+            },
+            'Volume of the failsafe alert sound.',
+            sectionName
+        );
+        this.addDirectTextInput(
+            'Custom Failsafe Sound',
+            '',
+            (value) => {
+                AlertUtils.setCustomFailsafeSound(value);
+            },
+            'Optional .wav file name (placed in failsafes/sounds) or a full path to use instead of the built-in sounds. Click the box to browse for a .wav file.',
+            sectionName,
+            (input) => this._browseForCustomSound(input)
+        );
+        this.addDirectButton(
+            'Preview Alert',
+            () => {
+                AlertUtils.previewAlert();
+            },
+            'Plays the selected failsafe sound as a preview.',
+            sectionName
+        );
     }
 
     isBanReason(text) {
         if (!text) return false;
         return text.includes('banned') || text.includes('cheating') || text.includes('boosting') || text.includes('security');
+    }
+
+    _browseForCustomSound(input) {
+        try {
+            const JFileChooser = Java.type('javax.swing.JFileChooser');
+            const FileNameExtensionFilter = Java.type('javax.swing.filechooser.FileNameExtensionFilter');
+            const chooser = new JFileChooser();
+            chooser.setDialogTitle('Select a .wav failsafe sound');
+            chooser.setFileFilter(new FileNameExtensionFilter('WAV audio files', 'wav'));
+            chooser.setAcceptAllFileFilterUsed(false);
+
+            const result = chooser.showOpenDialog(null);
+            if (result !== JFileChooser.APPROVE_OPTION) return;
+
+            const path = String(chooser.getSelectedFile().getAbsolutePath());
+            input.text = path;
+            input.value = path;
+            if (typeof input.callback === 'function') input.callback(path);
+        } catch (e) {
+            console.error('V5 Caught error' + e + e.stack);
+        }
     }
 
     postBanLog(reason) {

--- a/modules/other/MacroControllers.js
+++ b/modules/other/MacroControllers.js
@@ -1,4 +1,5 @@
 import { ModuleBase } from '../../utils/ModuleBase';
+import { MacroState } from '../../utils/MacroState';
 import { Mixin } from '../../utils/MixinManager';
 
 class Controller extends ModuleBase {
@@ -30,6 +31,17 @@ class Controller extends ModuleBase {
             (value) => Mixin.set('renderLimiter', value?.find?.((option) => option.enabled)?.name || 'Off'),
             'Limits render distance or cancels rendering while macro is running.',
             'Off',
+            sectionName
+        );
+
+        this.addDirectToggle(
+            'Picture-in-Picture (PiP)',
+            (value) => {
+                const pip = MacroState.getModule('PiP');
+                if (pip && typeof pip.toggle === 'function') pip.toggle(value);
+            },
+            'Shrinks the game window into a small always-on-top picture-in-picture window. Configure it in Modules > Visuals > PiP.',
+            false,
             sectionName
         );
     }

--- a/modules/other/MacroScheduler.js
+++ b/modules/other/MacroScheduler.js
@@ -10,6 +10,7 @@ const STATE = {
     RUNNING: 'Running',
     RESTING: 'Resting',
     RETURNING: 'Returning',
+    MINIBREAK: 'Mini Break',
 };
 
 class MacroScheduler extends ModuleBase {
@@ -26,6 +27,12 @@ class MacroScheduler extends ModuleBase {
         this.macroTimeMax = 140;
         this.breakTimeMin = 50;
         this.breakTimeMax = 100;
+        this.disconnectOnBreak = true;
+        this.randomBreakDuration = true;
+        this.waitOnIsland = false;
+        this.miniBreaksEnabled = false;
+        this.miniBreakIntervalMin = 15;
+        this.miniBreakDurationSec = 30;
 
         this.configPath = 'scheduler_data.json';
         this.state = STATE.IDLE;
@@ -34,6 +41,10 @@ class MacroScheduler extends ModuleBase {
         this.breakDurationMs = 0;
         this.returnStep = 0;
         this.overlayShown = false;
+        this.miniBreakEnd = 0;
+        this.nextMiniBreakAt = 0;
+        this.paused = false;
+        this.pausedRemainingMs = 0;
 
         this.worldUnloadTimer = new Timer();
 
@@ -63,12 +74,58 @@ class MacroScheduler extends ModuleBase {
             'Minimum break duration.',
             sectionName
         );
+        this.addDirectToggle(
+            'Disconnect During Break',
+            (v) => (this.disconnectOnBreak = !!v),
+            'Disconnects from the server while resting. Disable to stay in game with macros stopped.',
+            true,
+            sectionName
+        );
+        this.addDirectToggle(
+            'Random Break Duration',
+            (v) => (this.randomBreakDuration = !!v),
+            'Picks a random break length within the range. Disable to always use the minimum break duration.',
+            true,
+            sectionName
+        );
+        this.addDirectToggle(
+            'Wait on Island',
+            (v) => (this.waitOnIsland = !!v),
+            'Stays connected and waits on the island during breaks instead of disconnecting. Overrides Disconnect During Break.',
+            false,
+            sectionName
+        );
+        this.addDirectToggle(
+            'Enable Mini Breaks',
+            (v) => (this.miniBreaksEnabled = !!v),
+            'Takes short AFK pauses at your current location while macroing.',
+            false,
+            sectionName
+        );
+        this.addDirectSlider(
+            'Mini Break Every (m)',
+            1,
+            120,
+            this.miniBreakIntervalMin,
+            (v) => (this.miniBreakIntervalMin = v),
+            'How often a mini break is taken.',
+            sectionName
+        );
+        this.addDirectSlider(
+            'Mini Break Duration (s)',
+            5,
+            300,
+            this.miniBreakDurationSec,
+            (v) => (this.miniBreakDurationSec = v),
+            'How long each mini break lasts.',
+            sectionName
+        );
 
         this.createSchedulerOverlay([
             {
                 title: 'Scheduler',
                 data: {
-                    Status: () => this.state,
+                    Status: () => (this.paused ? 'Paused' : this.state),
                     'Time Left': () => this.formatTimeLeft(),
                     Active: () => this.getActiveMacroDisplay(),
                 },
@@ -89,6 +146,10 @@ class MacroScheduler extends ModuleBase {
         this.timerEnd = Number.isFinite(data.timerEnd) ? data.timerEnd : 0;
         this.breakDurationMs = Number.isFinite(data.breakDurationMs) ? data.breakDurationMs : 0;
         this.returnStep = Number.isFinite(data.returnStep) ? Math.max(0, Math.min(3, data.returnStep)) : 0;
+        this.miniBreakEnd = Number.isFinite(data.miniBreakEnd) ? data.miniBreakEnd : 0;
+        this.nextMiniBreakAt = Number.isFinite(data.nextMiniBreakAt) ? data.nextMiniBreakAt : 0;
+        this.paused = data.paused === true;
+        this.pausedRemainingMs = Number.isFinite(data.pausedRemainingMs) ? Math.max(0, data.pausedRemainingMs) : 0;
     }
 
     saveState() {
@@ -98,6 +159,10 @@ class MacroScheduler extends ModuleBase {
             timerEnd: this.timerEnd,
             breakDurationMs: this.breakDurationMs,
             returnStep: this.returnStep,
+            miniBreakEnd: this.miniBreakEnd,
+            nextMiniBreakAt: this.nextMiniBreakAt,
+            paused: this.paused,
+            pausedRemainingMs: this.pausedRemainingMs,
         });
     }
 
@@ -109,7 +174,7 @@ class MacroScheduler extends ModuleBase {
             this.returnStep = 0;
         }
 
-        if (this.state === STATE.RUNNING && now >= this.timerEnd) {
+        if (this.state === STATE.RUNNING && !this.paused && now >= this.timerEnd) {
             this.endSession();
         } else if (this.state === STATE.RESTING && now >= this.timerEnd) {
             this.beginReturn();
@@ -148,6 +213,9 @@ class MacroScheduler extends ModuleBase {
             case STATE.RETURNING:
                 this.handleReturning();
                 break;
+            case STATE.MINIBREAK:
+                this.handleMiniBreak();
+                break;
         }
     }
 
@@ -175,12 +243,21 @@ class MacroScheduler extends ModuleBase {
         const now = Date.now();
         const enabled = this.getSchedulableMacros();
 
-        if (enabled.length === 0) {
-            this.state = STATE.IDLE;
-            this.timerEnd = 0;
-            this.trackedMacros = [];
-            this.saveState();
+        if (this.paused) {
+            if (enabled.length > 0) {
+                this.timerEnd = now + this.pausedRemainingMs;
+                this.paused = false;
+                this.pausedRemainingMs = 0;
+                this.nextMiniBreakAt = this.miniBreaksEnabled ? now + this._nextMiniBreakDelayMs() : 0;
+                this.saveState();
+                this.message('&aSession resumed.');
+            }
             this.updateOverlay();
+            return;
+        }
+
+        if (enabled.length === 0) {
+            this.pauseSession();
             return;
         }
 
@@ -192,6 +269,12 @@ class MacroScheduler extends ModuleBase {
 
         if (now >= this.timerEnd) {
             this.endSession();
+            return;
+        }
+
+        if (this.miniBreaksEnabled && this.nextMiniBreakAt === 0) this._scheduleNextMiniBreak();
+        if (this.miniBreaksEnabled && now >= this.nextMiniBreakAt) {
+            this.startMiniBreak();
             return;
         }
 
@@ -208,6 +291,15 @@ class MacroScheduler extends ModuleBase {
         }
     }
 
+    pauseSession() {
+        this.pausedRemainingMs = Math.max(0, this.timerEnd - Date.now());
+        this.timerEnd = 0;
+        this.paused = true;
+        this.saveState();
+        this.updateOverlay();
+        this.message('&eSession paused. Resume by re-enabling the macro.');
+    }
+
     handleResting() {
         if (Date.now() >= this.timerEnd) {
             if (this.trackedMacros.length === 0) {
@@ -217,8 +309,47 @@ class MacroScheduler extends ModuleBase {
                 this.updateOverlay();
                 return;
             }
+            if (this.waitOnIsland) {
+                this.message('&aBreak over, resuming macros.');
+                this.startTrackedMacros();
+                this.sendSchedulerConnectEmbed();
+                this.beginSession();
+                return;
+            }
             this.beginReturn();
         }
+    }
+
+    startMiniBreak() {
+        this.stopTrackedMacros();
+        this.state = STATE.MINIBREAK;
+        this.miniBreakEnd = Date.now() + Math.max(1, this.miniBreakDurationSec) * 1000;
+        this.message(`&eMini break started, AFKing in place for ${this.miniBreakDurationSec}s.`);
+        this.saveState();
+        this.updateOverlay();
+    }
+
+    handleMiniBreak() {
+        Client.stopMovement();
+
+        if (Date.now() >= this.miniBreakEnd) {
+            this.message('&aMini break over, resuming macros.');
+            this.startTrackedMacros();
+            this.state = STATE.RUNNING;
+            this.nextMiniBreakAt = Date.now() + this._nextMiniBreakDelayMs();
+            this.saveState();
+            this.updateOverlay();
+        }
+    }
+
+    _scheduleNextMiniBreak() {
+        this.nextMiniBreakAt = Date.now() + this._nextMiniBreakDelayMs();
+        this.saveState();
+    }
+
+    _nextMiniBreakDelayMs() {
+        const baseMs = Math.max(1, this.miniBreakIntervalMin) * 60000;
+        return baseMs * (0.8 + Math.random() * 0.4);
     }
 
     handleReturning() {
@@ -275,23 +406,30 @@ class MacroScheduler extends ModuleBase {
 
     beginSession() {
         this.state = STATE.RUNNING;
+        this.paused = false;
+        this.pausedRemainingMs = 0;
         const duration = this.randomDuration(this.macroTimeMin, this.macroTimeMax);
         this.timerEnd = Date.now() + duration;
         this.returnStep = 0;
+        this.nextMiniBreakAt = this.miniBreaksEnabled ? Date.now() + this._nextMiniBreakDelayMs() : 0;
         this.saveState();
         this.updateOverlay();
     }
 
     endSession() {
-        this.breakDurationMs = this.randomDuration(this.breakTimeMin, this.breakTimeMax);
+        this.breakDurationMs = this.randomBreakDuration
+            ? this.randomDuration(this.breakTimeMin, this.breakTimeMax)
+            : Math.min(this.breakTimeMin, this.breakTimeMax) * 60000;
         const breakTime = TimeUtils.formatDurationMs(this.breakDurationMs);
         const cleanBreakTime = breakTime.includes(' ') ? breakTime.replace(/ (?=[^ ]+$)/, ' and ') : breakTime;
 
         this.stopTrackedMacros();
         this.sendSchedulerDisconnectEmbed(cleanBreakTime);
 
-        const reason = `Scheduler: Resting for ${cleanBreakTime}`;
-        this.disconnect(reason);
+        if (this.disconnectOnBreak && !this.waitOnIsland) {
+            const reason = `Scheduler: Resting for ${cleanBreakTime}`;
+            this.disconnect(reason);
+        }
 
         this.state = STATE.RESTING;
         this.timerEnd = Date.now() + this.breakDurationMs;
@@ -308,7 +446,7 @@ class MacroScheduler extends ModuleBase {
 
     cancelScheduledMacro(macroName) {
         if (!macroName || !this.enabled) return false;
-        if (this.state !== STATE.RESTING && this.state !== STATE.RETURNING) return false;
+        if (this.state !== STATE.RESTING && this.state !== STATE.RETURNING && this.state !== STATE.MINIBREAK) return false;
 
         const index = this.trackedMacros.indexOf(macroName);
         if (index === -1) return false;
@@ -322,6 +460,8 @@ class MacroScheduler extends ModuleBase {
             this.timerEnd = 0;
             this.breakDurationMs = 0;
             this.returnStep = 0;
+            this.miniBreakEnd = 0;
+            this.nextMiniBreakAt = 0;
             this.message(`&e${macroName} disabled.`);
         } else {
             this.message(`&e${macroName} disabled, ${this.trackedMacros.length} others remaining.`);
@@ -442,10 +582,17 @@ class MacroScheduler extends ModuleBase {
     formatTimeLeft() {
         if (this.state === STATE.IDLE) return 'Waiting';
 
-        const remaining = Math.max(0, this.timerEnd - Date.now());
+        const remaining = this.paused
+            ? Math.max(0, this.pausedRemainingMs)
+            : this.state === STATE.MINIBREAK
+              ? Math.max(0, this.miniBreakEnd - Date.now())
+              : Math.max(0, this.timerEnd - Date.now());
         const timeStr = TimeUtils.formatDurationMs(remaining);
 
-        return this.state === STATE.RETURNING ? `Returning (${timeStr})` : timeStr;
+        if (this.state === STATE.RETURNING) return `Returning (${timeStr})`;
+        if (this.state === STATE.MINIBREAK) return `Mini Break (${timeStr})`;
+        if (this.paused) return `Paused (${timeStr})`;
+        return timeStr;
     }
 
     getActiveMacroDisplay() {

--- a/modules/visuals/PiP.js
+++ b/modules/visuals/PiP.js
@@ -1,0 +1,220 @@
+import { GLFW, isWindows } from '../../utils/Constants';
+import { ModuleBase } from '../../utils/ModuleBase';
+import { ScheduleTask } from '../../utils/ScheduleTask';
+import { Utils } from '../../utils/Utils';
+
+const MouseInfo = Java.type('java.awt.MouseInfo');
+const MemoryUtil = Java.type('org.lwjgl.system.MemoryUtil');
+
+const PIP_WIDTH = 420;
+const PIP_HEIGHT = 252;
+const PIP_X = 0;
+const PIP_Y = 0;
+
+const POS_X = MemoryUtil.memAllocInt(1);
+const POS_Y = MemoryUtil.memAllocInt(1);
+const SIZE_W = MemoryUtil.memAllocInt(1);
+const SIZE_H = MemoryUtil.memAllocInt(1);
+
+class PiP extends ModuleBase {
+    constructor() {
+        super({
+            name: 'PiP',
+            subcategory: 'Visuals',
+            description: 'Shrinks the game window into a small always-on-top window.',
+            tooltip: 'Shrinks the game window into a small picture-in-picture window. Drag it with the middle mouse button. Windows only.',
+        });
+
+        this.alwaysOnTop = true;
+        this.dragWithMiddleMouse = true;
+        this._applied = false;
+        this._saved = null;
+        this._lastMouse = null;
+        this._blocked = false;
+        this._blockedMessageShown = false;
+        this._pipErrorLogged = false;
+
+        this._constructedAtLoad = true;
+        ScheduleTask(() => {
+            this._constructedAtLoad = false;
+        });
+
+        this.addToggle(
+            'Always on Top',
+            (value) => {
+                this.alwaysOnTop = value;
+                if (this.enabled && this._applied) this._setFloating(this._handle(), value);
+            },
+            'Keeps the PiP window above all other windows.',
+            true
+        );
+        this.addToggle(
+            'Drag with Middle Mouse',
+            (value) => {
+                this.dragWithMiddleMouse = value;
+            },
+            'Hold the middle mouse button and move the cursor to drag the PiP window.',
+            true
+        );
+
+        this.on('tick', () => this._onTick());
+    }
+
+    onEnable() {
+        if (!isWindows) {
+            this.message('&cPiP is only available on Windows.');
+            this.toggle(false);
+            return;
+        }
+
+        if (this._constructedAtLoad) {
+            this._constructedAtLoad = false;
+            this.message('&cPiP was auto-restored from saved settings. Disabling it - toggle it manually to use.');
+            this._persistDisabled();
+            this.toggle(false);
+            return;
+        }
+
+        this._applied = false;
+        this._lastMouse = null;
+        this._blocked = false;
+        this._blockedMessageShown = false;
+        this._pipErrorLogged = false;
+    }
+
+    onDisable() {
+        if (this._applied && this._saved) {
+            try {
+                const handle = this._handle();
+                if (handle) {
+                    this._setFloating(handle, false);
+                    GLFW.glfwSetWindowSize(handle, this._saved.width, this._saved.height);
+                    GLFW.glfwSetWindowPos(handle, this._saved.x, this._saved.y);
+                }
+            } catch (e) {
+                this._logError(e);
+            }
+        }
+
+        this._applied = false;
+        this._saved = null;
+        this._lastMouse = null;
+        this._blocked = false;
+        this._blockedMessageShown = false;
+    }
+
+    _handle() {
+        return GLFW.glfwGetCurrentContext();
+    }
+
+    _getSize(handle) {
+        GLFW.glfwGetWindowSize(handle, SIZE_W, SIZE_H);
+        return { width: SIZE_W.get(0), height: SIZE_H.get(0) };
+    }
+
+    _getPos(handle) {
+        GLFW.glfwGetWindowPos(handle, POS_X, POS_Y);
+        return { x: POS_X.get(0), y: POS_Y.get(0) };
+    }
+
+    _setFloating(handle, value) {
+        if (!handle) return;
+        try {
+            GLFW.glfwSetWindowAttrib(handle, GLFW.GLFW_FLOATING, value ? GLFW.GLFW_TRUE : GLFW.GLFW_FALSE);
+        } catch (e) {
+            this._logError(e);
+        }
+    }
+
+    _apply(handle) {
+        if (GLFW.glfwGetWindowMonitor(handle) !== 0) {
+            if (!this._blocked) {
+                this._blocked = true;
+                if (!this._blockedMessageShown) {
+                    this._blockedMessageShown = true;
+                    this.message('&cPiP needs windowed mode. Press F11 to switch out of fullscreen.');
+                }
+            }
+            return;
+        }
+
+        this._blocked = false;
+
+        this._saved = {
+            x: this._getPos(handle).x,
+            y: this._getPos(handle).y,
+            width: this._getSize(handle).width,
+            height: this._getSize(handle).height,
+        };
+
+        GLFW.glfwSetWindowSize(handle, PIP_WIDTH, PIP_HEIGHT);
+        GLFW.glfwSetWindowPos(handle, PIP_X, PIP_Y);
+        this._setFloating(handle, this.alwaysOnTop);
+
+        this._applied = true;
+        this._lastMouse = null;
+    }
+
+    _onTick() {
+        if (!this.enabled) return;
+
+        const handle = this._handle();
+        if (!handle) return;
+
+        if (!this._applied) {
+            try {
+                this._apply(handle);
+            } catch (e) {
+                this._logError(e);
+                this.toggle(false);
+            }
+            return;
+        }
+
+        if (!this._applied || !this.dragWithMiddleMouse) return;
+
+        if (GLFW.glfwGetMouseButton(handle, GLFW.GLFW_MOUSE_BUTTON_MIDDLE) !== GLFW.GLFW_PRESS) {
+            this._lastMouse = null;
+            return;
+        }
+
+        try {
+            const mouse = MouseInfo.getPointerInfo().getLocation();
+            const mouseX = mouse.getX();
+            const mouseY = mouse.getY();
+
+            if (this._lastMouse) {
+                const dx = mouseX - this._lastMouse.x;
+                const dy = mouseY - this._lastMouse.y;
+                GLFW.glfwSetWindowPos(handle, this._getPos(handle).x + dx, this._getPos(handle).y + dy);
+            }
+
+            this._lastMouse = { x: mouseX, y: mouseY };
+        } catch (e) {
+            this._logError(e);
+        }
+    }
+
+    _logError(e) {
+        if (this._pipErrorLogged) return;
+        this._pipErrorLogged = true;
+        console.error('V5 Caught error' + e + e.stack);
+    }
+
+    _persistDisabled() {
+        try {
+            const settings = Utils.getConfigFile('config.json') || {};
+            if (settings && settings.PiP) {
+                settings.PiP.Enabled = false;
+                if (settings['Macro Controllers'] && typeof settings['Macro Controllers'] === 'object') {
+                    settings['Macro Controllers']['Picture-in-Picture (PiP)'] = false;
+                }
+                Utils.writeConfigFile('config.json', settings);
+            }
+        } catch (e) {
+            console.error('V5 Caught error' + e + e.stack);
+        }
+    }
+}
+
+new PiP();

--- a/utils/CommissionUtils.js
+++ b/utils/CommissionUtils.js
@@ -4,8 +4,16 @@ import Pathfinder from './pathfinder/PathFinder';
 import { Guis } from './player/Inventory';
 import { Rotations } from './player/Rotations';
 
+const PIGEON_STAGE_ROD = 0;
+const PIGEON_STAGE_PIGEON = 1;
+const PIGEON_STAGE_CLICK = 2;
+const PIGEON_STAGE_TOOL = 3;
+const PIGEON_STAGE_WAIT = 4;
+const PIGEON_COOLDOWN_MS = 5200;
+const PIGEON_MAX_FAIL_STREAK = 3;
+
 export class CommissionClaimer {
-    constructor({ getLocations, ensureToolEquipped, isClaiming, delay, onClaimsExhausted, onPathStart, onPathFailed, canInteract, useEtherwarp }) {
+    constructor({ getLocations, ensureToolEquipped, isClaiming, delay, onClaimsExhausted, onPathStart, onPathFailed, canInteract, useEtherwarp, rodSlot, getToolSlot }) {
         this.getLocations = getLocations;
         this.ensureToolEquipped = ensureToolEquipped;
         this.isClaiming = isClaiming;
@@ -15,14 +23,21 @@ export class CommissionClaimer {
         this.onPathFailed = onPathFailed || (() => {});
         this.canInteract = canInteract || (() => true);
         this.useEtherwarp = useEtherwarp || (() => false);
+        this.getRodSlot = rodSlot || (() => null);
+        this.getToolSlot = getToolSlot || (() => -1);
         this.npcRotationPending = false;
         this.npcRotationToken = 0;
+        this.pigeonStage = PIGEON_STAGE_ROD;
+        this.lastPigeonUseAt = 0;
+        this.pigeonFailStreak = 0;
+        this.pigeonFallbackActive = false;
     }
 
     handle() {
         if (!Player.getPlayer()) return;
 
         if (Guis.guiName() === 'Commissions') {
+            this.resetPigeonClaimState();
             const container = Player.getContainer();
             if (!container) return;
 
@@ -34,18 +49,91 @@ export class CommissionClaimer {
             return;
         }
 
+        const rodSlot = this.getRodSlot ? this.getRodSlot() : null;
+        const hasRod = typeof rodSlot === 'number' && rodSlot >= 0;
+
         const pigeonSlot = Guis.findItemInHotbar('Royal Pigeon');
-        if (pigeonSlot !== -1) {
-            if (Player.getHeldItemIndex() !== pigeonSlot) {
-                Guis.setItemSlot(pigeonSlot);
-                this.delay(3);
-            } else {
-                Client.rightClick();
-                this.delay(10);
-            }
+        if (pigeonSlot !== -1 && !this.pigeonFallbackActive) {
+            this.cancelNpcRotation();
+            this.handlePigeonClaim(pigeonSlot, rodSlot, hasRod);
             return;
         }
 
+        this.pigeonStage = PIGEON_STAGE_ROD;
+        this.handleNpcClaim(hasRod, rodSlot);
+    }
+
+    handlePigeonClaim(pigeonSlot, rodSlot, hasRod) {
+        const now = Date.now();
+
+        switch (this.pigeonStage) {
+            case PIGEON_STAGE_ROD:
+                if (hasRod) {
+                    if (Player.getHeldItemIndex() !== rodSlot) {
+                        Guis.setItemSlot(rodSlot);
+                        this.delay(2);
+                        return;
+                    }
+                    Client.rightClick();
+                    this.pigeonStage = PIGEON_STAGE_PIGEON;
+                    this.delay(2);
+                    return;
+                }
+                this.pigeonStage = PIGEON_STAGE_PIGEON;
+                return;
+
+            case PIGEON_STAGE_PIGEON:
+                if (Player.getHeldItemIndex() !== pigeonSlot) {
+                    Guis.setItemSlot(pigeonSlot);
+                    this.delay(2);
+                    return;
+                }
+                this.pigeonStage = PIGEON_STAGE_CLICK;
+                return;
+
+            case PIGEON_STAGE_CLICK:
+                if (now - this.lastPigeonUseAt < PIGEON_COOLDOWN_MS) {
+                    this.pigeonStage = PIGEON_STAGE_WAIT;
+                    return;
+                }
+                Client.rightClick();
+                this.lastPigeonUseAt = now;
+                this.pigeonStage = PIGEON_STAGE_TOOL;
+                this.delay(2);
+                return;
+
+            case PIGEON_STAGE_TOOL:
+                this.equipToolFast();
+                this.pigeonStage = PIGEON_STAGE_WAIT;
+                return;
+
+            case PIGEON_STAGE_WAIT:
+            default:
+                if (now - this.lastPigeonUseAt >= PIGEON_COOLDOWN_MS) {
+                    if (++this.pigeonFailStreak >= PIGEON_MAX_FAIL_STREAK) {
+                        this.pigeonFailStreak = 0;
+                        this.pigeonFallbackActive = true;
+                        Chat.message('&cRoyal Pigeon claim failed repeatedly, walking to the emissary instead.');
+                        return;
+                    }
+                    this.pigeonStage = PIGEON_STAGE_ROD;
+                    return;
+                }
+                this.ensureToolEquipped();
+                return;
+        }
+    }
+
+    equipToolFast() {
+        const toolSlot = this.getToolSlot();
+        if (typeof toolSlot === 'number' && toolSlot >= 0) {
+            Guis.setItemSlot(toolSlot);
+            return;
+        }
+        this.ensureToolEquipped();
+    }
+
+    handleNpcClaim(hasRod, rodSlot) {
         const locations = this.getLocations();
         if (!locations.length) return;
 
@@ -59,7 +147,7 @@ export class CommissionClaimer {
         }
 
         if (MathUtils.distanceToPlayerPoint(target) <= 3 && !this.isPathing()) {
-            if (!this.ensureToolEquipped()) return;
+            if (!hasRod && !this.ensureToolEquipped()) return;
             if (Math.abs(Player.getMotionX()) + Math.abs(Player.getMotionZ()) >= 0.04) return;
 
             if (!Rotations.active) {
@@ -71,6 +159,18 @@ export class CommissionClaimer {
                     this.npcRotationPending = false;
                     if (!this.isClaiming() || this.isPathing()) return;
                     if (!this.canInteract()) return;
+
+                    if (hasRod) {
+                        if (Player.getHeldItemIndex() !== rodSlot) {
+                            Guis.setItemSlot(rodSlot);
+                            this.delay(1);
+                            return;
+                        }
+                        Client.rightClick();
+                        this.delay(10);
+                        return;
+                    }
+
                     Client.leftClick();
                     this.delay(10);
                 });
@@ -81,9 +181,16 @@ export class CommissionClaimer {
         this.pathToNpc(locations);
     }
 
+    resetPigeonClaimState() {
+        this.pigeonStage = PIGEON_STAGE_ROD;
+        this.lastPigeonUseAt = 0;
+        this.pigeonFailStreak = 0;
+        this.pigeonFallbackActive = false;
+        this.cancelNpcRotation();
+    }
+
     pathToNpc(locations) {
         if (this.isPathing()) return;
-
         this.onPathStart();
         const walk = () => {
             Pathfinder.findPath(locations, (success) => {

--- a/utils/ModuleBase.js
+++ b/utils/ModuleBase.js
@@ -438,9 +438,10 @@ export class ModuleBase {
      * @param {function} callback - Callback function when text changes
      * @param {string} [description=null] - Description/tooltip
      * @param {string} [sectionName=null] - Optional: Section header within Settings
+     * @param {function} [onBoxClick=null] - Optional: Called with the TextInput when its box is clicked instead of starting to type
      */
-    addDirectTextInput(title, defaultValue, callback, description = null, sectionName = null) {
-        return Categories.addSettingsTextInput(title, defaultValue, callback, description, sectionName, 'Settings');
+    addDirectTextInput(title, defaultValue, callback, description = null, sectionName = null, onBoxClick = null) {
+        return Categories.addSettingsTextInput(title, defaultValue, callback, description, sectionName, onBoxClick);
     }
 
     /**

--- a/utils/Ungrab.js
+++ b/utils/Ungrab.js
@@ -29,7 +29,7 @@ class UngrabManager {
             mc.mouseHandler.releaseMouse();
 
             if (isLinux) {
-                GLFW.glfwSetInputMode(mc.getWindow().handle(), GLFW.GLFW_CURSOR, GLFW.GLFW_CURSOR_NORMAL);
+                GLFW.glfwSetInputMode(GLFW.glfwGetCurrentContext(), GLFW.GLFW_CURSOR, GLFW.GLFW_CURSOR_NORMAL);
             }
         }
     }
@@ -62,7 +62,7 @@ class UngrabManager {
         const mc = Client.getMinecraft();
         if (mc.screen == null) {
             mc.mouseHandler.grabMouse();
-            GLFW.glfwSetInputMode(mc.getWindow().handle(), GLFW.GLFW_CURSOR, GLFW.GLFW_CURSOR_DISABLED);
+            GLFW.glfwSetInputMode(GLFW.glfwGetCurrentContext(), GLFW.GLFW_CURSOR, GLFW.GLFW_CURSOR_DISABLED);
         }
     }
 }

--- a/utils/pathfinder/EtherwarpPathfinder.js
+++ b/utils/pathfinder/EtherwarpPathfinder.js
@@ -4,6 +4,7 @@ import { ClientboundPingPacket, ServerboundUseItemPacket } from '../Packets';
 import { Guis } from '../player/Inventory';
 import { finiteNumber } from '../NumberUtils';
 import { RotationGCD } from '../player/RotationGCD';
+import RotationModule from '../player/Rotations';
 import { ServerInfo } from '../player/ServerInfo';
 import { ScheduleTask } from '../ScheduleTask';
 import { Utils } from '../Utils';
@@ -217,7 +218,7 @@ class EtherwarpPathHandler {
 
     getPingDelayTicks() {
         const pingMs = ServerInfo.getPing() || 0;
-        return Math.ceil(pingMs / 50) + 2;
+        return Math.max(1, Math.ceil(pingMs / 50) + 2 + (RotationModule.ETHERWARP_PING_ADJUSTMENT ?? 0));
     }
 
     isExecutionContextValid(token) {
@@ -435,7 +436,31 @@ class EtherwarpPathHandler {
         }
         if (!this.ensureEtherwarpHeld(token, () => this.executeHop(token, index))) return;
 
-        RotationGCD.applyToPlayer(angles.yaw, angles.pitch);
+        let yaw = angles.yaw;
+        let pitch = angles.pitch;
+        const overshoot = Number(RotationModule.ETHERWARP_OVERSHOOT ?? 0);
+        if (overshoot > 0) {
+            const node = this.path[index];
+            if (this.isNodeValid(node)) {
+                const px = Number(Player.getX());
+                const py = Player.getEyePosition?.().y?.() ?? Number(Player.getY()) + Player.getPlayer().getEyeHeight();
+                const pz = Number(Player.getZ());
+                if ([px, py, pz].every(Number.isFinite)) {
+                    const dx = Number(node.x) - px;
+                    const dy = Number(node.y) - py;
+                    const dz = Number(node.z) - pz;
+                    const dist = Math.hypot(dx, dy, dz) || 1;
+                    const scale = (dist + overshoot) / dist;
+                    const tx = px + dx * scale;
+                    const ty = py + dy * scale;
+                    const tz = pz + dz * scale;
+                    yaw = (Math.atan2(-(tx - px), tz - pz) * 180) / Math.PI;
+                    pitch = (Math.atan2(-(ty - py), Math.hypot(tx - px, tz - pz)) * 180) / Math.PI;
+                }
+            }
+        }
+
+        RotationGCD.applyToPlayer(yaw, pitch);
         this.sendEtherwarpClick();
         if (index >= this.path.length - 1) {
             this.startAwaitingFinalArrival(token);

--- a/utils/player/Rotations.js
+++ b/utils/player/Rotations.js
@@ -19,15 +19,18 @@ class RotationConfig extends ModuleBase {
         this.ROTATION_SPEED = 400;
         this.rotationMode = 'Non-linear';
         this.DAMPING_DIST = 60;
+        this.RANDOMNESS = 1;
+        this.ETHERWARP_OVERSHOOT = 0;
+        this.ETHERWARP_PING_ADJUSTMENT = 0;
 
         this.addDirectMultiToggle(
             'Rotation Mode',
-            ['Linear', 'Non-linear (recommended)', 'Instant'],
+            ['Linear', 'Non-linear (recommended)', 'Instant', 'Bezier'],
             true,
             (value) => {
                 this.rotationMode = value?.find((opt) => opt.enabled)?.name;
             },
-            '• Non-linear rotations have offsets making them more human-like\n• Linear rotations are smoother and more precise\n• Instant rotations snap to the target immediately.',
+            '• Non-linear rotations have offsets making them more human-like\n• Linear rotations are smoother and more precise\n• Instant rotations snap to the target immediately.\n• Bezier rotations follow a smooth ease-in-out cubic bezier curve.',
             'Non-linear (recommended)',
             'Rotations'
         );
@@ -41,6 +44,42 @@ class RotationConfig extends ModuleBase {
                 this.ROTATION_SPEED = v * 10;
             },
             'Degrees per second',
+            'Rotations'
+        );
+
+        this.addDirectSlider(
+            'Randomness',
+            0,
+            100,
+            100,
+            (v) => {
+                this.RANDOMNESS = v / 100;
+            },
+            'How strong the random curve offset is on non-linear/bezier rotations.',
+            'Rotations'
+        );
+
+        this.addDirectSlider(
+            'Etherwarp Overshoot',
+            0,
+            5,
+            0,
+            (v) => {
+                this.ETHERWARP_OVERSHOOT = v;
+            },
+            'Extra blocks the etherwarp aims past the waypoint to compensate for teleports landing short.',
+            'Rotations'
+        );
+
+        this.addDirectSlider(
+            'Etherwarp Ping Adjustment',
+            -10,
+            10,
+            0,
+            (v) => {
+                this.ETHERWARP_PING_ADJUSTMENT = Math.round(v);
+            },
+            'Added tick delay to compensate for network latency on etherwarp arrival.',
             'Rotations'
         );
     }
@@ -291,9 +330,23 @@ class RotationController {
         const warmup = this.request?.type === 'angles' ? 1 : Math.min(timeAlive * 4, 1);
         const damping = Math.min(distance / RotationModule.DAMPING_DIST, 1);
         const speed = RotationModule.ROTATION_SPEED * (this.request?.speedMultiplier ?? 1) * Math.sqrt(damping);
-        const step = (speed * warmup + 10) * deltaTime;
+
+        let step = (speed * warmup + 10) * deltaTime;
+
+        if (RotationModule.rotationMode === 'Bezier') {
+            const progress = this.getProgress(distance);
+            const eased = this.getBezierVelocity(progress);
+            step = (speed * (0.25 + 0.75 * eased) * warmup + 10) * deltaTime;
+        }
 
         return Math.min(distance, step) / distance;
+    }
+
+    // Velocity follows the derivative of the cubic ease-in-out curve, giving a smooth
+    // bell shape: gentle start, peak mid-rotation, gentle stop (no end-of-rotation snap).
+    getBezierVelocity(t) {
+        const p = Math.max(0, Math.min(1, t));
+        return p < 0.5 ? 12 * p * p : 12 * (1 - p) * (1 - p);
     }
 
     getProgress(distance) {
@@ -306,7 +359,8 @@ class RotationController {
 
         const ease = Math.sin(progress * Math.PI);
         const fade = 1 - progress;
-        const strength = this.initialDistance * 0.18 * ease * fade;
+        let strength = this.initialDistance * 0.18 * ease * fade * RotationModule.RANDOMNESS;
+        if (RotationModule.rotationMode === 'Bezier') strength *= 0.5;
 
         return {
             x: Math.cos(this.curveSeed) * strength,


### PR DESCRIPTION
Failsafe:
- Add customizable failsafe sound volume
- Add custom failsafe sound support using .wav files
- Add failsafe sound preview button
- Add desktop notification on macro check
- Add grab/focus game window option on macro check

Scheduler:
- Add mini breaks with configurable interval and duration
- Add pause/resume behavior when no schedulable macros are enabled
- Add disconnect during break toggle
- Add random break duration toggle
- Add wait-on-island break option
- Improve scheduler state persistence and overlay status display

Macros:
- Add rod swap on commission claim
- Add Excavator click, placement, and reopen delays
- Add Combat Bot target name and Skyblock name filters (untested)
- add Mining Bot ability rod swap and blue wool priority
- Add Lobby Hopper nucleus warp option

Client/GUI:
- Add Picture-in-Picture module for Windows
- Add TextInput onBoxClick support
- Prevent settings loading from applying module states in some GUIs
- Improve Ungrab GLFW context handling

Rotations/Pathing:
- Add Bezier rotation mode (useless but yeah)
- Add rotation randomness slider
- Add Etherwarp overshoot compensation
- Add Etherwarp ping adjustment