### PR TITLE
Fixed this issue https://discord.com/channels/777635824845455360/1536853421871734856

### DIFF
--- a/modules/mining/OreMacro.js
+++ b/modules/mining/OreMacro.js
@@ -329,7 +329,7 @@ class OreMiner extends ModuleBase {
         this.message('&cUsage: /v5 mining ore edit <add|deployable|remove|removemine|undo|clear|list|done>');
     }
 
-    addWaypoint(type, indexArg) {
+addWaypoint(type, indexArg) {
         const route = this.loadedWaypoints || (this.loadedWaypoints = []);
         const index = indexArg === undefined ? route.length : Number.parseInt(indexArg, 10);
         if (!Number.isInteger(index) || index < 0 || index > route.length) {
@@ -351,7 +351,9 @@ class OreMiner extends ModuleBase {
 
     addMineBlock(type, indexArg) {
         const route = this.loadedWaypoints;
-        const index = indexArg === undefined ? route?.length - 1 : Number.parseInt(indexArg, 10);
+        const defaultIndex = this.selectedWaypoint ?? (route?.length ? route.length - 1 : -1);
+        const index = indexArg === undefined ? defaultIndex : Number.parseInt(indexArg, 10);
+        
         if (!route?.length || !Number.isInteger(index) || index < 0 || index >= route.length) {
             return this.message('&cAdd a waypoint first, or provide a valid waypoint index.');
         }
@@ -361,13 +363,17 @@ class OreMiner extends ModuleBase {
         if (!pos) return this.message('&cLook at a block within 10 blocks.');
 
         this.recordUndo();
-        route[index].minableBlocks.push({
+        
+        const blockData = {
             x: pos.getX(),
             y: pos.getY(),
-            z: pos.getZ(),
-            oneTap: type === 'onetap',
-            rOneTap: type === 'ronetap',
-        });
+            z: pos.getZ()
+        };
+        
+        if (type === 'onetap') blockData.oneTap = true;
+        if (type === 'ronetap') blockData.rOneTap = true;
+
+        route[index].minableBlocks.push(blockData);
         this.selectedWaypoint = index;
         this.message(`&aAdded ${type} block to waypoint [${index}].`);
     }

--- a/modules/mining/OreMacro.js
+++ b/modules/mining/OreMacro.js
@@ -329,7 +329,7 @@ class OreMiner extends ModuleBase {
         this.message('&cUsage: /v5 mining ore edit <add|deployable|remove|removemine|undo|clear|list|done>');
     }
 
-addWaypoint(type, indexArg) {
+    addWaypoint(type, indexArg) {
         const route = this.loadedWaypoints || (this.loadedWaypoints = []);
         const index = indexArg === undefined ? route.length : Number.parseInt(indexArg, 10);
         if (!Number.isInteger(index) || index < 0 || index > route.length) {

--- a/modules/mining/OreMacro.js
+++ b/modules/mining/OreMacro.js
@@ -353,7 +353,7 @@ class OreMiner extends ModuleBase {
         const route = this.loadedWaypoints;
         const defaultIndex = this.selectedWaypoint ?? (route?.length ? route.length - 1 : -1);
         const index = indexArg === undefined ? defaultIndex : Number.parseInt(indexArg, 10);
-        
+
         if (!route?.length || !Number.isInteger(index) || index < 0 || index >= route.length) {
             return this.message('&cAdd a waypoint first, or provide a valid waypoint index.');
         }
@@ -363,13 +363,13 @@ class OreMiner extends ModuleBase {
         if (!pos) return this.message('&cLook at a block within 10 blocks.');
 
         this.recordUndo();
-        
+
         const blockData = {
             x: pos.getX(),
             y: pos.getY(),
-            z: pos.getZ()
+            z: pos.getZ(),
         };
-        
+
         if (type === 'onetap') blockData.oneTap = true;
         if (type === 'ronetap') blockData.rOneTap = true;
 


### PR DESCRIPTION
https://discord.com/channels/777635824845455360/1536853421871734856

Issue explained:
If you make a new route from scratch and your first waypoint does not have a minable block index (like for type mining) it will add:
“oneTap”: false,
“rOneTap”: false

After every minable index for subsequent tp/walk indexes. And the expected behavior is that it doesn't add those for minable indexes.