### PR TITLE
Fix movement directional key states

### DIFF
--- a/utils/player/Movement.js
+++ b/utils/player/Movement.js
@@ -3,23 +3,20 @@ import { Utils } from '../Utils';
 let lastActionTime = Date.now();
 
 function setKeysBasedOnYaw(yaw, shouldJump) {
-    Client.stopMovement();
     if (Client.isInGui() && !Client.isInChat()) return;
 
-    if (yaw > -50 && yaw < 50) Client.setKey('w', true);
-    if (yaw > -135.5 && yaw < -7) Client.setKey('a', true);
-    if (yaw > 7 && yaw < 135.5) Client.setKey('d', true);
-    if (yaw > 135.5 || yaw < -135.5) Client.setKey('s', true);
+    Client.setKey('w', yaw > -50 && yaw < 50);
+    Client.setKey('a', yaw > -135.5 && yaw < -7);
+    Client.setKey('d', yaw > 7 && yaw < 135.5);
+    Client.setKey('s', yaw > 135.5 || yaw < -135.5);
 
     const motionScale = Math.abs(Player.getMotionX()) + Math.abs(Player.getMotionZ());
-    if (shouldJump && motionScale < 0.04 && Date.now() - lastActionTime > 500 && Utils.playerIsCollided()) {
-        Client.setKey('space', true);
-        lastActionTime = Date.now();
-    }
+    const jump = shouldJump && motionScale < 0.04 && Date.now() - lastActionTime > 500 && Utils.playerIsCollided();
+    Client.setKey('space', jump);
+    if (jump) lastActionTime = Date.now();
 }
 
 function setKeysForStraightLine(yaw, shouldJump, ignoreBottomSlab) {
-    Client.stopMovement();
     if (Client.isInGui() && !Client.isInChat()) return;
 
     const quadrants = [
@@ -34,12 +31,8 @@ function setKeysForStraightLine(yaw, shouldJump, ignoreBottomSlab) {
         { min: 112.5, max: 157.5, keys: ['s', 'd'] },
     ];
 
-    for (const { min, max, keys } of quadrants) {
-        if (yaw >= min && yaw <= max) {
-            keys.forEach((key) => Client.setKey(key, true));
-            break;
-        }
-    }
+    const keys = quadrants.find(({ min, max }) => yaw >= min && yaw <= max)?.keys ?? [];
+    ['w', 'a', 's', 'd'].forEach((key) => Client.setKey(key, keys.includes(key)));
 
     Client.setKey('space', !!shouldJump && Utils.playerIsCollided(!!ignoreBottomSlab));
 }


### PR DESCRIPTION
### Motivation
- Ensure directional movement functions actually press and release the correct WASD keys for a given yaw instead of relying on `Client.stopMovement()` which could leave stale or missing key states.

### Description
- In `utils/player/Movement.js` `setKeysBasedOnYaw` now explicitly sets each of `w`, `a`, `s`, and `d` to the appropriate boolean expression and `setKeysForStraightLine` computes the quadrant keys and synchronizes all four directional states so only the intended keys are held; jump handling was also made explicit to avoid lingering `space` state.

### Testing
- Ran formatting with `prettier --write utils/player/Movement.js` and performed `git diff --check` and `git status --short`, all of which completed successfully; no automated test runner was executed per repository instructions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8b61f98b2c8333880916aef928f238)