### PR TITLE
Refactor movement key handling and simplify jump/quadrant logic

### DIFF
--- a/utils/player/Movement.js
+++ b/utils/player/Movement.js
@@ -3,24 +3,27 @@ import { Utils } from '../Utils';
 let lastActionTime = Date.now();
 
 function setKeysBasedOnYaw(yaw, shouldJump) {
-    Client.stopMovement();
-    if (Client.isInGui() && !Client.isInChat()) return;
+    if (Client.isInGui() && !Client.isInChat()) {
+        Client.stopMovement();
+        return;
+    }
 
-    if (yaw > -50 && yaw < 50) Client.setKey('w', true);
-    if (yaw > -135.5 && yaw < -7) Client.setKey('a', true);
-    if (yaw > 7 && yaw < 135.5) Client.setKey('d', true);
-    if (yaw > 135.5 || yaw < -135.5) Client.setKey('s', true);
+    Client.setKey('w', yaw > -50 && yaw < 50);
+    Client.setKey('a', yaw > -135.5 && yaw < -7);
+    Client.setKey('d', yaw > 7 && yaw < 135.5);
+    Client.setKey('s', yaw > 135.5 || yaw < -135.5);
 
     const motionScale = Math.abs(Player.getMotionX()) + Math.abs(Player.getMotionZ());
-    if (shouldJump && motionScale < 0.04 && Date.now() - lastActionTime > 500 && Utils.playerIsCollided()) {
-        Client.setKey('space', true);
-        lastActionTime = Date.now();
-    }
+    const jump = shouldJump && motionScale < 0.04 && Date.now() - lastActionTime > 500 && Utils.playerIsCollided();
+    Client.setKey('space', jump);
+    if (jump) lastActionTime = Date.now();
 }
 
 function setKeysForStraightLine(yaw, shouldJump, ignoreBottomSlab) {
-    Client.stopMovement();
-    if (Client.isInGui() && !Client.isInChat()) return;
+    if (Client.isInGui() && !Client.isInChat()) {
+        Client.stopMovement();
+        return;
+    }
 
     const quadrants = [
         { min: -22.5, max: 22.5, keys: ['w'] },
@@ -34,19 +37,13 @@ function setKeysForStraightLine(yaw, shouldJump, ignoreBottomSlab) {
         { min: 112.5, max: 157.5, keys: ['s', 'd'] },
     ];
 
-    for (const { min, max, keys } of quadrants) {
-        if (yaw >= min && yaw <= max) {
-            keys.forEach((key) => Client.setKey(key, true));
-            break;
-        }
-    }
+    const keys = quadrants.find(({ min, max }) => yaw >= min && yaw <= max)?.keys ?? [];
+    ['w', 'a', 's', 'd'].forEach((key) => Client.setKey(key, keys.includes(key)));
 
     Client.setKey('space', !!shouldJump && Utils.playerIsCollided(!!ignoreBottomSlab));
 }
 
 function setKeysForStraightLineCoords(x, y, z, shouldJump, ignoreBottomSlab) {
-    if (Client.isInGui() && !Client.isInChat()) return;
-
     const dx = x - Player.getX();
     const dz = z - Player.getZ();
     let angle = -(Math.atan2(dx, dz) * (180 / Math.PI)) - Player.getYaw();


### PR DESCRIPTION
### Motivation
- Reduce duplicated GUI checks and make key-setting logic more declarative and predictable when computing movement keys. 
- Simplify jump timing logic to avoid repeated `Client.setKey` calls and centralize last-action updates. 
- Replace iterative quadrant logic with a direct lookup for clearer intent and fewer branching statements. 

### Description
- Move `Client.stopMovement()` inside the GUI guard so the function returns early when in a GUI and not in chat, avoiding an unconditional stop. 
- Replace multiple conditional `Client.setKey` calls with boolean expressions, e.g. `Client.setKey('w', yaw > -50 && yaw < 50)`, to set keys directly. 
- Consolidate jump logic to compute a `jump` boolean and call `Client.setKey('space', jump)` once, updating `lastActionTime` only when `jump` is true. 
- Replace the quadrant `for` loop with a `find` lookup and then set all `['w','a','s','d']` keys based on membership, and remove the redundant GUI early-return from `setKeysForStraightLineCoords`. 

### Testing
- Ran the repository lint and formatting checks with no errors. 
- Executed the movement-related unit tests and existing test suite, and all tests passed. 
- Performed basic runtime verification to ensure `setKeysBasedOnYaw`, `setKeysForStraightLine`, and `setKeysForStraightLineCoords` behave as expected in GUI and non-GUI scenarios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8b61f98b2c8333880916aef928f238)