### PR TITLE
Release movement keys when GUI opens

### DIFF
--- a/utils/player/Movement.js
+++ b/utils/player/Movement.js
@@ -3,7 +3,10 @@ import { Utils } from '../Utils';
 let lastActionTime = Date.now();
 
 function setKeysBasedOnYaw(yaw, shouldJump) {
-    if (Client.isInGui() && !Client.isInChat()) return;
+    if (Client.isInGui() && !Client.isInChat()) {
+        Client.stopMovement();
+        return;
+    }
 
     Client.setKey('w', yaw > -50 && yaw < 50);
     Client.setKey('a', yaw > -135.5 && yaw < -7);
@@ -17,7 +20,10 @@ function setKeysBasedOnYaw(yaw, shouldJump) {
 }
 
 function setKeysForStraightLine(yaw, shouldJump, ignoreBottomSlab) {
-    if (Client.isInGui() && !Client.isInChat()) return;
+    if (Client.isInGui() && !Client.isInChat()) {
+        Client.stopMovement();
+        return;
+    }
 
     const quadrants = [
         { min: -22.5, max: 22.5, keys: ['w'] },
@@ -38,8 +44,6 @@ function setKeysForStraightLine(yaw, shouldJump, ignoreBottomSlab) {
 }
 
 function setKeysForStraightLineCoords(x, y, z, shouldJump, ignoreBottomSlab) {
-    if (Client.isInGui() && !Client.isInChat()) return;
-
     const dx = x - Player.getX();
     const dz = z - Player.getZ();
     let angle = -(Math.atan2(dx, dz) * (180 / Math.PI)) - Player.getYaw();


### PR DESCRIPTION
### Motivation

- Prevent synthetic movement keys (W/A/S/D/space) from remaining held when a non-chat GUI opens, which previously allowed modules like `RouteWalker` to keep moving after an inventory/GUI opened.

### Description

- In `utils/player/Movement.js` call `Client.stopMovement()` before returning when `Client.isInGui() && !Client.isInChat()` in `setKeysBasedOnYaw`.
- In `utils/player/Movement.js` call `Client.stopMovement()` before returning when `Client.isInGui() && !Client.isInChat()` in `setKeysForStraightLine`.
- Remove the early GUI guard from `setKeysForStraightLineCoords` so it routes through `setKeysForStraightLine` and benefits from the key-release behavior.

### Testing

- Ran `prettier --write utils/player/Movement.js` and the file was formatted successfully.
- Ran `git diff --check` and no whitespace/format issues were reported.
- No automated test runner exists for this repo per project guidelines, so no unit/integration tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8b759c187c833399e9047f00ffa2be)