### PR TITLE
Add item name blacklist to Bazaar to NPC macro

### DIFF
--- a/modules/bazaar/BazaarNpcMacro.js
+++ b/modules/bazaar/BazaarNpcMacro.js
@@ -86,6 +86,13 @@ class BazaarNpcMacro extends ModuleBase {
             (percent) => (this.minProfitPercent = percent),
             'Minimum profit as a percentage of the NPC sell value.'
         );
+        this.itemNameBlacklist = [];
+        this.addTextInput(
+            'Item Name Blacklist',
+            '',
+            (value) => (this.itemNameBlacklist = String(value).split(',').map(clean).filter(Boolean)),
+            'Case-insensitive item names to exclude, separated by commas.'
+        );
         this.createOverlay([
             {
                 title: 'Status',
@@ -301,7 +308,15 @@ class BazaarNpcMacro extends ModuleBase {
             const item = items[id];
             const product = bazaar.products[id];
             const prices = (product.sell_summary || []).map((order) => Number(order.pricePerUnit)).filter(Number.isFinite);
-            if (!item || !prices.length || this.skippedIds.has(id) || activeNames.has(clean(item.name))) continue;
+            const itemName = clean(item?.name);
+            if (
+                !item ||
+                !prices.length ||
+                this.skippedIds.has(id) ||
+                activeNames.has(itemName) ||
+                this.itemNameBlacklist.some((blocked) => itemName.includes(blocked))
+            )
+                continue;
 
             const orderPrice = Math.ceil((Math.max(...prices) + 0.1) * 10) / 10;
             const npcPrice = Number(item.npc_sell_price);


### PR DESCRIPTION
### Motivation
- Provide a simple, comma-separated, case-insensitive item blacklist for the Bazaar→NPC macro so users can exclude unwanted items from flip selection (same UX idea as CombatBot). 

### Description
- Add `this.itemNameBlacklist` and an `addTextInput('Item Name Blacklist', ...)` that parses comma-separated entries into normalized blacklist tokens, and skip Bazaar candidates in `findBestFlips` when the cleaned item name contains any configured blacklist token. 

### Testing
- Ran `prettier --write modules/bazaar/BazaarNpcMacro.js` and `git diff --check`, both succeeded and the change was committed as `6fd1337`; no automated test suite was run per repository guidelines.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a961841b8ac832c81450340f50d77a2)