### PR TITLE
New pest killing mode, mana regex fix, and configurable swap cooldown

### DIFF
--- a/modules/farming/FarmingMacro.js
+++ b/modules/farming/FarmingMacro.js
@@ -144,14 +144,9 @@ export class FarmingMacro extends ModuleBase {
                 return this.beginRewarp(returnPoint, true);
             }
         }
-
-        // if we're not looping, and we're at rewarp point
         if (!looping && this.isAtPoint(player, this.points.end)) {
             return this.beginRewarp(this.points.start, rewarpSettings.pestKiller && Utils.getGardenPestStatus().gardenPests >= rewarpSettings.pestThreshold);
         }
-
-        // if we're looping and hsould run bar ntasks.
-        // dont carea bout this case
         if (looping && this.shouldRunBarnTasks()) {
             ChatLib.command('sethome');
             return this.beginRewarp({ x: player.getX(), y: player.getY(), z: player.getZ() });

--- a/modules/farming/FarmingMacro.js
+++ b/modules/farming/FarmingMacro.js
@@ -135,17 +135,23 @@ export class FarmingMacro extends ModuleBase {
         if (farmingSettings.killNearbyPests && !rewarpSettings.pestKiller && this.handlePest(player)) return;
 
         const looping = rewarpSettings.looping;
+        const hybrid = rewarpSettings.hybrid;
         if (rewarpSettings.pestKiller && Utils.getGardenPestStatus().gardenPests >= rewarpSettings.pestThreshold) {
             const pestColumnClear = this.isPestColumnClear(player);
-            if (looping || pestColumnClear) {
+            if (looping || hybrid || pestColumnClear) {
                 const returnPoint = { x: player.getX(), y: player.getY(), z: player.getZ() };
-                if (looping) ChatLib.command('sethome');
+                if (looping || hybrid) ChatLib.command('sethome');
                 return this.beginRewarp(returnPoint, true);
             }
         }
+
+        // if we're not looping, and we're at rewarp point
         if (!looping && this.isAtPoint(player, this.points.end)) {
             return this.beginRewarp(this.points.start, rewarpSettings.pestKiller && Utils.getGardenPestStatus().gardenPests >= rewarpSettings.pestThreshold);
         }
+
+        // if we're looping and hsould run bar ntasks.
+        // dont carea bout this case
         if (looping && this.shouldRunBarnTasks()) {
             ChatLib.command('sethome');
             return this.beginRewarp({ x: player.getX(), y: player.getY(), z: player.getZ() });

--- a/modules/farming/LoadoutHandler.js
+++ b/modules/farming/LoadoutHandler.js
@@ -17,6 +17,7 @@ class LoadoutHandler extends ModuleBase {
         this.pestSpawningSlot = 1;
         this.pestKillingSlot = 1;
         this.visitorSlot = 1;
+        this.postSwapDelay = 4;
         this.pestSpawnSwapCooldown = 140;
         this.currentSlot = null;
         this.targetSlot = null;
@@ -34,6 +35,7 @@ class LoadoutHandler extends ModuleBase {
             (value) => (this.pestSpawnSwapCooldown = Math.round(value)),
             'Switches to the pest spawning loadout at or below this cooldown in seconds.'
         );
+        this.addSlider('Post Swap Delay', 1, 20, this.postSwapDelay, (value) => (this.postSwapDelay = Math.round(value)));
 
         register('tick', () => this.tick());
     }
@@ -57,7 +59,7 @@ class LoadoutHandler extends ModuleBase {
         this.switching = true;
         ScheduleTask(5, () => {
             if (Guis.guiName()?.includes('(1/3) Loadouts')) Guis.closeInv();
-            ScheduleTask(4, () => (this.switching = false));
+            ScheduleTask(this.postSwapDelay, () => (this.switching = false));
         });
     }
 }

--- a/modules/farming/rewarp/RewarpHandler.js
+++ b/modules/farming/rewarp/RewarpHandler.js
@@ -46,7 +46,7 @@ class RewarpHandler {
         if (runPhilip) this.tasks.push(philipMacro);
         const hasBarnTasks = this.tasks.length > 0;
         if (runPestKiller) this.tasks.push(pestKiller, autoSell);
-        this.phase = hasBarnTasks ? PHASES.BARN : this.tasks.length ? PHASES.DECIDING : PHASES.REWARP;
+        this.phase = hasBarnTasks ? PHASES.BARN : PHASES.DECIDING;
         this.nextActionAt = runPestKiller && !hasBarnTasks ? 0 : Date.now() + Utils.randomInt(farmingDelays.rewarpDelayMin, farmingDelays.rewarpDelayMax);
     }
 
@@ -89,7 +89,9 @@ class RewarpHandler {
                     break;
                 }
             }
-            if (!this.task) this.phase = this.runPestKiller && !rewarpSettings.looping ? PHASES.RETURNING : PHASES.REWARP;
+            // when do we rewarp
+            // if we're looping, or we're hybrid. otherwise we fly back
+            if (!this.task) this.phase = this.runPestKiller && (rewarpSettings.looping || rewarpSettings.hybrid) ? PHASES.REWARP : PHASES.RETURNING;
         }
 
         if (this.phase === PHASES.RUNNING && this.task.tick()) this.phase = PHASES.DECIDING;

--- a/modules/farming/rewarp/RewarpSettings.js
+++ b/modules/farming/rewarp/RewarpSettings.js
@@ -12,6 +12,7 @@ class RewarpSettings extends ModuleBase {
         });
 
         this.looping = false;
+        this.hybrid = false;
         this.triggerRadius = 2;
         this.rewarpButtons = [];
         this.runVisitorMacro = false;
@@ -24,10 +25,11 @@ class RewarpSettings extends ModuleBase {
 
         this.addMultiToggle(
             'Rewarp Style',
-            ['Start/End', 'Looping'],
+            ['Start/End', 'Looping', 'Hybrid'],
             true,
             (options) => {
                 this.looping = options[1].enabled;
+                this.hybrid = options[2].enabled;
                 this.rewarpButtons.forEach((button) => (button.visible = !this.looping));
             },
             'Start/End warps at the saved endpoint. Looping sets home before running barn tasks.',

--- a/utils/Utils.js
+++ b/utils/Utils.js
@@ -130,8 +130,8 @@ class LocationDetector {
 class ManaDetector {
     constructor() {
         this.currentMana = null;
-        this.manaPatternWithColors = /(?:\u00A7b)?([\d,]+)\/([\d,]+)(?:\u270E|\uE003)\s*(?:Mana|(?:\u00A73)?([\d,]+)\u02AC)\s*/;
-        this.manaPattern = /([\d,]+)\/([\d,]+)(?:\u270E|\uE003)\s*(?:Mana|([\d,]+)\u02AC)\s*/;
+        this.manaPatternWithColors = /(?:\u00A7b)?([\d,]+)\/([\d,]+)(?:\u270E|\uE003)\s*/;
+        this.manaPattern = /([\d,]+)\/([\d,]+)(?:\u270E|\uE003)\s*/;
 
         register('worldLoad', () => this.reset());
         register('packetReceived', (packet) => {
@@ -152,6 +152,7 @@ class ManaDetector {
             const stripped = actionBar.replace(/\u00A7[0-9A-FK-ORa-fk-or]/g, '');
             match = stripped.match(this.manaPattern);
         }
+
         if (!match) return;
 
         this.currentMana = Number(match[1].replace(/,/g, ''));

--- a/utils/pathfinder/PathWalker/PathAote.js
+++ b/utils/pathfinder/PathWalker/PathAote.js
@@ -183,6 +183,7 @@ class PathAote {
 
     hasEnoughMana() {
         const mana = Utils.getCurrentMana();
+
         if (mana === null) {
             this.debug('mana unavailable');
             //return false;


### PR DESCRIPTION
## Note
These changes were made to fix issues I was hitting locally. Not sure if they're the right fix for the project overall, or if there's context I'm missing. Happy to adjust or drop any of them if there's a better approach or they're not actually needed.

## Changes
- **Hybrid pest killing mode**: adds a new pest-killing strategy which combines the two existing modes, sets spawn mid farming, kills pests, rewarps, and then flies to the start of the farm at the end of the cycle.
- **Mana regex fix**: updates the mana-detection regex to match the game's updated action bar format, fixing mana-based triggers that broke after the update
- **Configurable post-swap cooldown**: adds a GUI slider so the wait after a loadout swap finishes can be tuned, instead of a fixed delay