### PR TITLE
feat: add GUI onboarding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 desktop.ini
 .DS_Store
+scriptoutputs/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,8 @@ UI code lives in `gui/`;
 failsafe implementations live in `failsafes/impl/`.
 Keep images, SVGs, and bundled data in `assets/`.
 
+Development-only utilities belong in `scripts/`. Prefer Node's standard library; existing V5Loader development dependencies may be reused when matching runtime behavior requires them. Never import these tools from CTJS/runtime code, and write all generated artifacts to the normally gitignored `scriptoutputs/` directory.
+
 Refer to `typings.d.ts` for the available runtime APIs. This is an extremely large file so do not attempt to read it all at once. Use searching methods to determin what you want.
 
 ## Coding Style
@@ -44,6 +46,9 @@ Not lazy about: understanding the problem (read it fully and trace the real flow
 ## Build, Test, and Development Process
 
 There is no package manifest, build step, or automated test runner. Do not attempt to make or run any tests.
+
+Offline development scripts may be run directly with Node. They are not CTJS tests and must not launch Minecraft.
+The GUI preview must execute the real `gui/` sources and replay their captured `Render2D` calls; do not hardcode a parallel GUI layout in the renderer.
 
 You should run prettier formatting before completion.
 

--- a/README.md
+++ b/README.md
@@ -38,3 +38,15 @@ We highly recommend using UserScripts to create custom modules rather that modif
 4. Use `/ct console` to view the JavaScript console.
 
 More detailed contributor docs may be added in the future.
+
+## Offline Development Scripts
+
+Development-only tools live in `scripts/`. Node launchers use the standard library; render helpers may reuse V5Loader's existing development dependencies. Nothing in this directory may be imported by `loader.js` or other runtime files, and generated files belong in the normally gitignored `scriptoutputs/` directory.
+
+Render an offline GUI preview with:
+
+```sh
+node scripts/render-gui.mjs
+```
+
+This creates `scriptoutputs/v5-gui.png`. Pass `--plain` to omit the onboarding overlay. The script executes the real `gui/` module tree with deterministic runtime stubs, captures its `Render2D` calls, then replays them with V5Loader's exact Skija version and bundled font. GUI source changes therefore appear in the next render; Minecraft and CTJS are not started. Run `../V5Loader/gradlew build` once if the local Skija jars have not been downloaded yet.

--- a/gui/Onboarding.js
+++ b/gui/Onboarding.js
@@ -1,0 +1,123 @@
+import { Categories } from './categories/CategorySystem';
+import { getCategoryRect } from './categories/CategoryRenderer';
+import { Button } from './components/Button';
+import { ToggleButton } from './components/Toggle';
+import { saveSettings } from './GuiSave';
+import { FontSizes, PADDING, THEME, colorWithAlpha, drawRect, drawRoundedRectangleWithBorder, drawText } from './Utils';
+import { GuiRectangles, GuiState } from './core/GuiState';
+
+const STEPS = [
+    ['Welcome to V5', ['Here is a quick tour of the client.', 'You can revisit everything from the sidebar.']],
+    ['Dashboard', ['See active modules and session information', 'at a glance.'], 'Dashboard'],
+    ['Modules', ['Browse modules, configure them, and open', 'their documentation.'], 'Modules'],
+    ['Settings', ['Configure shared behavior, failsafes,', 'and your V5 profile.'], 'Settings'],
+    ['Theme', ['Adjust the GUI colors and layout', 'without changing module behavior.'], 'Theme'],
+    ['Privacy & safety', ['Choose what V5 may send and what happens on a ban.']],
+];
+
+const nextButton = new Button('', 0, 0, 'Next', null, { showContainer: false });
+const skipButton = new Button('', 0, 0, 'Skip', null, { showContainer: false });
+const telemetryToggle = new ToggleButton('Ban telemetry', 0, 0);
+const statisticsToggle = new ToggleButton('Anonymous statistics', 0, 0);
+const clippingToggle = new ToggleButton('Clip on ban', 0, 0);
+let step = 0;
+let active = false;
+
+const getSettingToggle = (title) =>
+    Categories.categories.find((category) => category.name === 'Settings')?.directComponents?.find((component) => component.title === title);
+
+const finish = (applyPreferences = false) => {
+    if (applyPreferences) {
+        [
+            ['Ban telemetry', telemetryToggle],
+            ['Clip on ban', clippingToggle],
+        ].forEach(([title, source]) => {
+            const target = getSettingToggle(title);
+            if (!target) return;
+            target.enabled = source.enabled;
+            target.animationProgress = source.enabled ? 1 : 0;
+            target.callback?.(source.enabled);
+        });
+        Config.setSendStatistics(statisticsToggle.enabled);
+        saveSettings();
+    }
+    Config.markWelcomeShown();
+    active = false;
+};
+
+const open = () => {
+    active = !Config.wasWelcomeShown();
+    step = 0;
+    if (!active) return;
+    telemetryToggle.enabled = getSettingToggle('Ban telemetry')?.enabled ?? true;
+    statisticsToggle.enabled = Config.getSendStatistics();
+    clippingToggle.enabled = getSettingToggle('Clip on ban')?.enabled ?? true;
+    telemetryToggle.animationProgress = telemetryToggle.enabled ? 1 : 0;
+    statisticsToggle.animationProgress = statisticsToggle.enabled ? 1 : 0;
+    clippingToggle.animationProgress = clippingToggle.enabled ? 1 : 0;
+};
+
+const draw = (mouseX, mouseY) => {
+    if (!active) return;
+
+    const current = STEPS[step];
+    const panel = GuiRectangles.RightPanel;
+    const preferences = step === STEPS.length - 1;
+    const width = Math.min(320, panel.width - PADDING * 4);
+    const height = preferences ? 138 : 112;
+    const x = panel.x + (panel.width - width) / 2;
+    const y = panel.y + (panel.height - height) / 2;
+
+    drawRect({ x: 0, y: 0, width: GuiState.getGuiWidth(), height: GuiState.getGuiHeight(), color: 0xaa000000 });
+
+    if (current[2]) {
+        const index = Categories.getVisibleCategories().findIndex((category) => category.name === current[2]);
+        if (index !== -1) {
+            drawRoundedRectangleWithBorder({
+                ...getCategoryRect(index),
+                radius: 8,
+                color: colorWithAlpha(THEME.ACCENT, 0.22),
+                borderWidth: 2,
+                borderColor: THEME.ACCENT,
+            });
+        }
+    }
+
+    drawRoundedRectangleWithBorder({ x, y, width, height, radius: 12, color: THEME.BG_WINDOW, borderWidth: 1, borderColor: THEME.BORDER });
+    drawText(current[0], x + 16, y + (preferences ? 16 : 20), FontSizes.HEADER, THEME.TEXT);
+    current[1].forEach((line, index) => drawText(line, x + 16, y + (preferences ? 30 : 40) + index * 11, FontSizes.REGULAR, THEME.TEXT_MUTED));
+
+    if (preferences) {
+        [telemetryToggle, statisticsToggle, clippingToggle].forEach((toggle, index) => {
+            toggle.x = x + 16;
+            toggle.y = y + 40 + index * 24;
+            toggle.optionPanelWidth = width - 16;
+            toggle.draw(mouseX, mouseY);
+        });
+    }
+
+    skipButton.x = x + 16;
+    skipButton.y = y + height - 24;
+    skipButton.draw(mouseX, mouseY);
+    nextButton.setButtonText(preferences ? 'Finish' : 'Next');
+    nextButton.x = x + width - 80;
+    nextButton.y = y + height - 24;
+    nextButton.draw(mouseX, mouseY);
+};
+
+const handleClick = (mouseX, mouseY) => {
+    if (!active) return false;
+    if (
+        step === STEPS.length - 1 &&
+        (telemetryToggle.handleClick(mouseX, mouseY) || statisticsToggle.handleClick(mouseX, mouseY) || clippingToggle.handleClick(mouseX, mouseY))
+    )
+        return true;
+    if (skipButton.handleClick(mouseX, mouseY)) finish();
+    else if (nextButton.handleClick(mouseX, mouseY)) {
+        if (step === STEPS.length - 1) finish(true);
+        else step++;
+    }
+    return true;
+};
+
+export const onboarding = { open, draw, handleClick, isActive: () => active };

--- a/gui/core/GuiEvents.js
+++ b/gui/core/GuiEvents.js
@@ -9,10 +9,12 @@ import { clamp, isInside } from '../Utils';
 import { drawGUI } from './GuiRenderer';
 import { GuiRectangles, GuiState } from './GuiState';
 import { macroToggleGui } from '../MacroToggleGui';
+import { onboarding } from '../Onboarding';
 
 const handleClick = (mouseX, mouseY) => {
     if (GuiState.isOpening) return;
     ({ x: mouseX, y: mouseY } = GuiState.toGuiCoordinates(mouseX, mouseY));
+    if (onboarding.handleClick(mouseX, mouseY)) return;
     if (GuiState.macroToggleOpen) return macroToggleGui.handleClick(mouseX, mouseY);
     if (
         isInside(mouseX, mouseY, GuiRectangles.Background) &&
@@ -30,6 +32,7 @@ const handleClick = (mouseX, mouseY) => {
 const handleMouseDrag = (mouseX, mouseY) => {
     if (GuiState.isOpening) return;
     ({ x: mouseX, y: mouseY } = GuiState.toGuiCoordinates(mouseX, mouseY));
+    if (onboarding.isActive()) return;
     if (GuiState.macroToggleOpen) return;
     if (GuiState.dragging) {
         const newX = mouseX - GuiRectangles.Background.dx;
@@ -48,6 +51,7 @@ const handleMouseDrag = (mouseX, mouseY) => {
 const handleScroll = (mouseX, mouseY, dir) => {
     if (GuiState.isOpening) return;
     ({ x: mouseX, y: mouseY } = GuiState.toGuiCoordinates(mouseX, mouseY));
+    if (onboarding.isActive()) return;
     if (GuiState.macroToggleOpen) return macroToggleGui.handleScroll(mouseX, mouseY, dir);
     categoryManager?.handleScroll(mouseX, mouseY, dir);
 };
@@ -80,6 +84,7 @@ const openGui = () => {
     loadSettings();
     categoryManager?.invalidateLayoutCache();
     categoryManager?.invalidateContentHeightCache();
+    onboarding.open();
     GuiState.myGui.open();
 };
 

--- a/gui/core/GuiRenderer.js
+++ b/gui/core/GuiRenderer.js
@@ -12,6 +12,7 @@ import { BORDER_WIDTH, PADDING, THEME, clamp, drawRect, drawRoundedRectangleWith
 import { ANIMATION_DURATION, GuiRectangles, GuiState } from './GuiState';
 import { GuiTooltip } from './GuiTooltip';
 import { macroToggleGui } from '../MacroToggleGui';
+import { onboarding } from '../Onboarding';
 
 export const drawGUI = (mouseX, mouseY) => {
     const elapsed = Date.now() - GuiState.openStartTime;
@@ -104,6 +105,7 @@ export const drawGUI = (mouseX, mouseY) => {
 
         GuiTooltip.update();
         GuiTooltip.draw(mouseX, mouseY);
+        onboarding.draw(mouseX, mouseY);
 
         Render2D.restore();
     } catch (e) {

--- a/modules/other/Failsafes.js
+++ b/modules/other/Failsafes.js
@@ -24,6 +24,7 @@ class Failsafes extends ModuleBase {
         this.slotChange = true;
         this.chatMention = true;
         this.playerGrief = true;
+        this.banTelemetry = true;
         this.clipOnBan = true;
         this.playerProximityDistance = 3;
         this.actionDelay = { low: 500, high: 2000 };
@@ -81,6 +82,15 @@ class Failsafes extends ModuleBase {
             sectionName
         );
         this.addDirectToggle(
+            'Ban telemetry',
+            (value) => {
+                this.banTelemetry = value;
+            },
+            'Send ban details to help track detection rates',
+            this.banTelemetry,
+            sectionName
+        );
+        this.addDirectToggle(
             'Clip on ban',
             (value) => {
                 this.clipOnBan = value;
@@ -135,7 +145,7 @@ class Failsafes extends ModuleBase {
     }
 
     postBanLog(reason) {
-        if (!reason?.includes('https://www.hypixel.net/appeal')) return;
+        if (!this.banTelemetry || !reason?.includes('https://www.hypixel.net/appeal')) return;
 
         const now = Date.now();
         if (now - this.lastBanLogTime < 60000) return;

--- a/scripts/CaptureGui.mjs
+++ b/scripts/CaptureGui.mjs
@@ -1,0 +1,187 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import vm from 'node:vm';
+
+const [root, requestsPath, commandsPath, metricsPath, mode] = process.argv.slice(2);
+const encode = (value) => Buffer.from(String(value)).toString('base64');
+const metricKey = (text, size) => `${size}\0${text}`;
+const metrics = new Map();
+if (metricsPath) {
+    for (const line of readFileSync(metricsPath, 'utf8').trim().split('\n')) {
+        if (!line) continue;
+        const [size, encoded, width] = line.split('\t');
+        metrics.set(metricKey(Buffer.from(encoded, 'base64').toString(), size), Number(width));
+    }
+}
+
+const commands = [];
+const measurements = new Map();
+const command = (name, ...args) => commands.push([name, ...args].join('\t'));
+const signed = (value) => value | 0;
+
+class Color {
+    constructor(red, green, blue, alpha = 1) {
+        if (green === undefined) {
+            const value = Number(red) >>> 0;
+            this.red = (value >>> 16) & 255;
+            this.green = (value >>> 8) & 255;
+            this.blue = value & 255;
+            this.alpha = (value >>> 24) & 255 || 255;
+        } else {
+            this.red = Math.round(red * 255);
+            this.green = Math.round(green * 255);
+            this.blue = Math.round(blue * 255);
+            this.alpha = Math.round(alpha * 255);
+        }
+    }
+    getRed() {
+        return this.red;
+    }
+    getGreen() {
+        return this.green;
+    }
+    getBlue() {
+        return this.blue;
+    }
+    getAlpha() {
+        return this.alpha;
+    }
+    getRGB() {
+        return signed((this.alpha << 24) | (this.red << 16) | (this.green << 8) | this.blue);
+    }
+}
+
+const font = {};
+const Render2D = {
+    screen: { getWidth: () => 480, getHeight: () => 270 },
+    getDefaultFont: () => font,
+    textWidth(text, size) {
+        const key = metricKey(text, size);
+        measurements.set(key, [size, text]);
+        return metrics.get(key) ?? String(text).length * Number(size) * 0.5;
+    },
+    text: (text, x, y, size, color, ignoredFont, align) => command('text', encode(text), x, y, size, signed(color), align),
+    drawRect: (x, y, width, height, color) => command('rect', x, y, width, height, signed(color)),
+    drawRoundedRect: (x, y, width, height, radius, color) => command('round', x, y, width, height, radius, signed(color)),
+    drawRoundedRectVaried: (x, y, width, height, color, tl, tr, br, bl) => command('varied', x, y, width, height, signed(color), tl, tr, br, bl),
+    drawImage: (path, x, y, width, height, radius = 0, alpha = 1) => command('image', encode(path), x, y, width, height, radius, alpha),
+    drawImageFromUrl: () => {},
+    drawDropShadow: (x, y, width, height, radius, blur, spread, color) => command('shadow', x, y, width, height, radius, blur, spread, signed(color)),
+    save: () => command('save'),
+    restore: () => command('restore'),
+    translate: (x, y) => command('translate', x, y),
+    scale: (x, y) => command('scale', x, y ?? x),
+    rotate: (degrees) => command('rotate', degrees),
+    scissor: (x, y, width, height) => command('scissor', x, y, width, height),
+    resetScissor: () => command('resetScissor'),
+    blurBackground: () => {},
+    globalAlpha: (alpha) => command('alpha', alpha),
+    registerV5Render: () => ({}),
+    unregisterV5Render: () => {},
+};
+
+class Gui {
+    isOpen() {
+        return true;
+    }
+    open() {}
+    close() {}
+    registerOpened() {}
+    registerClosed() {}
+    registerClicked() {}
+    registerMouseDragged() {}
+    registerMouseReleased() {}
+    registerScrolled() {}
+}
+
+const registration = new Proxy({}, { get: () => () => registration });
+const globals = {
+    console,
+    Buffer,
+    Render2D,
+    Gui,
+    Client: { getFPS: () => 144, getMouseX: () => -1, getMouseY: () => -1, getMinecraft: () => ({ execute: (callback) => callback() }) },
+    Config: { wasWelcomeShown: () => false, markWelcomeShown: () => {}, getSendStatistics: () => false, setSendStatistics: () => {} },
+    FileLib: { read: (folder, path) => readFileSync(resolve(root, path), 'utf8'), open: () => {} },
+    Keyboard: { KEY_NONE: 0, isKeyDown: () => false },
+    World: { getWorld: () => ({ playPlayerSound: () => {} }) },
+    register: () => registration,
+    cancel: () => {},
+    Java: { type: () => class {} },
+    java: { awt: { Color } },
+};
+const context = vm.createContext(globals);
+const cache = new Map();
+
+const synthetic = (identifier, exports) =>
+    new vm.SyntheticModule(
+        Object.keys(exports),
+        function () {
+            for (const [name, value] of Object.entries(exports)) this.setExport(name, value);
+        },
+        { context, identifier }
+    );
+
+const stubs = new Map([
+    [
+        resolve(root, 'utils/Constants.js'),
+        {
+            Color,
+            CLIENT_VERSION: JSON.parse(readFileSync(resolve(root, 'metadata.json'))).version,
+            globalAssetsDir: { getPath: () => resolve(root, 'assets') },
+            Identifier: { fromNamespaceAndPath: () => ({}) },
+            SoundCategory: { MASTER: {} },
+            SoundEvent: { createVariableRangeEvent: () => ({}) },
+            DataFlavor: {},
+            Toolkit: { getDefaultToolkit: () => ({}) },
+        },
+    ],
+    [
+        resolve(root, 'utils/MacroState.js'),
+        {
+            modules: new Map(),
+            getEnabledModulesRevision: () => 0,
+            getModule: () => null,
+        },
+    ],
+    [resolve(root, 'utils/Utils.js'), { getConfigFile: () => ({}), writeConfigFile: () => true, area: () => 'Garden', subArea: () => 'Plot 1' }],
+    [resolve(root, 'utils/TimeUtils.js'), { formatUptime: () => '00:12:34' }],
+    [resolve(root, 'utils/player/ServerInfo.js'), { getPing: () => 42, getPingColor: () => 0x55ff55, getTPS: () => 20, getTpsColor: () => 0x55ff55 }],
+    [resolve(root, 'utils/NetworkUtils.js'), { getDiscordPfpPath: () => null }],
+    [resolve(root, 'gui/GuiSave.js'), { loadSettings: () => {}, saveSettings: () => {} }],
+    [resolve(root, 'gui/OverlayUtils.js'), { OverlayManager: { openGui: () => {} } }],
+    [resolve(root, 'gui/MacroToggleGui.js'), { macroToggleGui: { draw: () => {} } }],
+    [resolve(root, 'gui/Changelog.js'), { drawChangelog: () => {}, getChangelogContentHeight: () => 0 }],
+]);
+
+const getModule = (path) => {
+    path = resolve(path.endsWith('.js') ? path : `${path}.js`);
+    if (cache.has(path)) return cache.get(path);
+    const stub = stubs.get(path);
+    const module = stub
+        ? synthetic(path, stub)
+        : new vm.SourceTextModule(readFileSync(path, 'utf8'), {
+              context,
+              identifier: path,
+              initializeImportMeta: (meta) => (meta.url = `file://${path}`),
+          });
+    cache.set(path, module);
+    return module;
+};
+
+const load = async (path) => {
+    const module = getModule(path);
+    if (module.status === 'unlinked') await module.link((specifier, parent) => getModule(resolve(dirname(parent.identifier), specifier)));
+    if (module.status === 'linked') await module.evaluate();
+    return module;
+};
+
+const renderer = await load(resolve(root, 'gui/core/GuiRenderer.js'));
+const state = (await load(resolve(root, 'gui/core/GuiState.js'))).namespace.GuiState;
+const onboarding = (await load(resolve(root, 'gui/Onboarding.js'))).namespace.onboarding;
+state.openStartTime = Date.now() - 1_000;
+if (mode !== '--plain') onboarding.open();
+renderer.namespace.drawGUI(-1, -1);
+
+writeFileSync(requestsPath, [...measurements.values()].map(([size, text]) => `${size}\t${encode(text)}`).join('\n'));
+writeFileSync(commandsPath, commands.join('\n'));

--- a/scripts/RenderGui.java
+++ b/scripts/RenderGui.java
@@ -1,0 +1,150 @@
+import io.github.humbleui.skija.*;
+import io.github.humbleui.skija.svg.SVGDOM;
+import io.github.humbleui.skija.svg.SVGLengthContext;
+import io.github.humbleui.types.RRect;
+import io.github.humbleui.types.Rect;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+@SuppressWarnings("deprecation")
+class RenderGui {
+    static Typeface typeface;
+    static final Map<Float, Font> fonts = new HashMap<>();
+    static Canvas canvas;
+    static float alpha = 1;
+
+    public static void main(String[] args) throws Exception {
+        if (args[0].equals("measure")) measure(Path.of(args[1]), Path.of(args[2]), Path.of(args[3]));
+        else render(Path.of(args[1]), Path.of(args[2]));
+    }
+
+    static void measure(Path loader, Path requests, Path output) throws Exception {
+        loadFont(loader.resolve("src/main/resources/assets/v5/font.otf"));
+        var lines = new StringBuilder();
+        for (var request : Files.readAllLines(requests)) {
+            if (request.isBlank()) continue;
+            var fields = request.split("\\t");
+            var size = Float.parseFloat(fields[0]);
+            var value = decode(fields[1]);
+            try (var line = TextLine.make(value, font(size))) {
+                lines.append(fields[0]).append('\t').append(fields[1]).append('\t').append(line.getWidth()).append('\n');
+            }
+        }
+        Files.writeString(output, lines);
+        closeFonts();
+    }
+
+    static void render(Path commands, Path output) throws Exception {
+        var loader = output.getParent().getParent().resolveSibling("V5Loader");
+        loadFont(loader.resolve("src/main/resources/assets/v5/font.otf"));
+        Files.createDirectories(output.getParent());
+        try (var surface = Surface.makeRasterN32Premul(960, 540)) {
+            canvas = surface.getCanvas();
+            canvas.clear(0);
+            canvas.scale(2, 2);
+            for (var line : Files.readAllLines(commands)) replay(line.split("\\t"));
+            try (var image = surface.makeImageSnapshot(); var png = image.encodeToData(EncodedImageFormat.PNG)) {
+                Files.write(output, png.getBytes());
+            }
+        }
+        closeFonts();
+        if (Files.size(output) < 1_000) throw new IllegalStateException("Incomplete GUI render");
+        System.out.println("Rendered " + output);
+    }
+
+    static void replay(String[] value) throws Exception {
+        switch (value[0]) {
+            case "save" -> canvas.save();
+            case "restore" -> canvas.restore();
+            case "translate" -> canvas.translate(f(value[1]), f(value[2]));
+            case "scale" -> canvas.scale(f(value[1]), f(value[2]));
+            case "rotate" -> canvas.rotate(f(value[1]));
+            case "scissor" -> { canvas.save(); canvas.clipRect(Rect.makeXYWH(f(value[1]), f(value[2]), f(value[3]), f(value[4])), true); }
+            case "resetScissor" -> canvas.restore();
+            case "alpha" -> alpha = f(value[1]);
+            case "rect" -> rect(f(value[1]), f(value[2]), f(value[3]), f(value[4]), i(value[5]));
+            case "round" -> round(f(value[1]), f(value[2]), f(value[3]), f(value[4]), f(value[5]), i(value[6]));
+            case "varied" -> varied(value);
+            case "text" -> text(value);
+            case "image" -> image(value);
+            case "shadow" -> shadow(value);
+        }
+    }
+
+    static void rect(float x, float y, float width, float height, int color) {
+        try (var paint = paint(color)) { canvas.drawRect(Rect.makeXYWH(x, y, width, height), paint); }
+    }
+
+    static void round(float x, float y, float width, float height, float radius, int color) {
+        try (var paint = paint(color)) { canvas.drawRRect(RRect.makeXYWH(x, y, width, height, Math.max(0, radius)), paint); }
+    }
+
+    static void varied(String[] v) {
+        var radii = new float[] { f(v[6]), f(v[6]), f(v[7]), f(v[7]), f(v[8]), f(v[8]), f(v[9]), f(v[9]) };
+        try (var paint = paint(i(v[5]))) { canvas.drawRRect(RRect.makeComplexXYWH(f(v[1]), f(v[2]), f(v[3]), f(v[4]), radii), paint); }
+    }
+
+    static void text(String[] v) {
+        var size = f(v[4]);
+        var x = f(v[2]);
+        var y = f(v[3]);
+        var align = Integer.parseInt(v[6]);
+        var font = font(size);
+        try (var line = TextLine.make(decode(v[1]), font); var paint = paint(i(v[5]))) {
+            var metrics = font.getMetrics();
+            var baseline = (align & 32) != 0 ? y - metrics.getDescent() : (align & 16) != 0 ? y - (metrics.getAscent() + metrics.getDescent()) / 2 : (align & 8) != 0 ? y - metrics.getAscent() : y;
+            var drawX = (align & 4) != 0 ? x - line.getWidth() : (align & 2) != 0 ? x - line.getWidth() / 2 : x;
+            canvas.drawTextLine(line, drawX, baseline, paint);
+        }
+    }
+
+    static void image(String[] v) throws Exception {
+        var path = Path.of(decode(v[1]));
+        try (var data = Data.makeFromBytes(Files.readAllBytes(path)); var dom = new SVGDOM(data)) {
+            var intrinsic = dom.getRoot().getIntrinsicSize(new SVGLengthContext(256, 256, 96));
+            var width = Math.max(1, Math.round(intrinsic.getX()));
+            var height = Math.max(1, Math.round(intrinsic.getY()));
+            try (var surface = Surface.makeRasterN32Premul(width, height)) {
+                surface.getCanvas().clear(0);
+                dom.setContainerSize(width, height);
+                dom.render(surface.getCanvas());
+                try (var image = surface.makeImageSnapshot(); var paint = new Paint().setAntiAlias(true).setAlphaf(alpha * f(v[7]))) {
+                    var destination = Rect.makeXYWH(f(v[2]), f(v[3]), f(v[4]), f(v[5]));
+                    if (f(v[6]) > 0) { canvas.save(); canvas.clipRRect(RRect.makeXYWH(destination.getLeft(), destination.getTop(), destination.getWidth(), destination.getHeight(), f(v[6])), true); }
+                    canvas.drawImageRect(image, Rect.makeWH(width, height), destination, SamplingMode.LINEAR, paint, true);
+                    if (f(v[6]) > 0) canvas.restore();
+                }
+            }
+        }
+    }
+
+    static void shadow(String[] v) {
+        try (var filter = MaskFilter.makeBlur(FilterBlurMode.NORMAL, f(v[6]) / 2); var paint = paint(i(v[8])).setMaskFilter(filter)) {
+            var spread = f(v[7]);
+            canvas.drawRRect(RRect.makeXYWH(f(v[1]) - spread, f(v[2]) - spread, f(v[3]) + spread * 2, f(v[4]) + spread * 2, f(v[5]) + spread), paint);
+        }
+    }
+
+    static Paint paint(int color) {
+        var sourceAlpha = (color >>> 24) & 255;
+        return new Paint().setAntiAlias(true).setColor((color & 0xffffff) | (Math.round(sourceAlpha * alpha) << 24));
+    }
+
+    static void loadFont(Path path) throws Exception {
+        try (var data = Data.makeFromBytes(Files.readAllBytes(path))) { typeface = FontMgr.getDefault().makeFromData(data); }
+        if (typeface == null) throw new IllegalStateException("Unable to load V5 font");
+    }
+
+    static Font font(float size) {
+        return fonts.computeIfAbsent(size, value -> new Font(typeface, value).setSubpixel(true).setEdging(FontEdging.SUBPIXEL_ANTI_ALIAS).setHinting(FontHinting.SLIGHT));
+    }
+
+    static void closeFonts() { fonts.values().forEach(Font::close); fonts.clear(); typeface.close(); }
+    static String decode(String value) { return new String(Base64.getDecoder().decode(value), StandardCharsets.UTF_8); }
+    static float f(String value) { return Float.parseFloat(value); }
+    static int i(String value) { return (int) Long.parseLong(value); }
+}

--- a/scripts/render-gui.mjs
+++ b/scripts/render-gui.mjs
@@ -1,0 +1,55 @@
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { delimiter, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const loader = join(root, '..', 'V5Loader');
+const cache = join(homedir(), '.gradle', 'caches', 'modules-2', 'files-2.1', 'io.github.humbleui');
+const temporary = mkdtempSync(join(tmpdir(), 'v5-gui-'));
+
+const findJar = (name) => {
+    let match;
+    const walk = (directory) => {
+        if (match || !existsSync(directory)) return;
+        for (const entry of readdirSync(directory, { withFileTypes: true })) {
+            const path = join(directory, entry.name);
+            if (entry.isDirectory()) walk(path);
+            else if (entry.name === name) match = path;
+        }
+    };
+    walk(cache);
+    return match;
+};
+
+const platform = { linux: 'linux-x64', darwin: process.arch === 'arm64' ? 'macos-arm64' : 'macos-x64', win32: 'windows-x64' }[process.platform];
+const jars = ['skija-shared-0.143.11.jar', `skija-${platform}-0.143.11.jar`, 'types-0.1.1.jar'].map(findJar);
+if (!platform || jars.some((jar) => !jar)) throw new Error('Skija 0.143.11 is missing; run ../V5Loader/gradlew build once');
+
+const run = (program, args) => {
+    const result = spawnSync(program, args, { stdio: 'inherit' });
+    if (result.error) throw result.error;
+    if (result.status) process.exit(result.status);
+};
+const java = (...args) => run('java', ['--enable-native-access=ALL-UNNAMED', '-cp', jars.join(delimiter), join(root, 'scripts', 'RenderGui.java'), ...args]);
+const capture = (metrics = '') =>
+    run('node', [
+        '--no-warnings',
+        '--experimental-vm-modules',
+        join(root, 'scripts', 'CaptureGui.mjs'),
+        root,
+        join(temporary, 'requests'),
+        join(temporary, 'commands'),
+        metrics,
+        ...process.argv.slice(2),
+    ]);
+
+try {
+    capture();
+    java('measure', loader, join(temporary, 'requests'), join(temporary, 'metrics'));
+    capture(join(temporary, 'metrics'));
+    java('render', join(temporary, 'commands'), join(root, 'scriptoutputs', 'v5-gui.png'));
+} finally {
+    rmSync(temporary, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary
- add first-open onboarding that highlights Dashboard, Modules, Settings, and Theme
- prompt for ban telemetry, anonymous statistics, and clip-on-ban preferences
- add a source-synced offline GUI renderer under `scripts/`

The existing per-module Docs button continues to open the matching `rdbt.top/docs/modules/...` page.

## Verification
- `node scripts/render-gui.mjs`
- Prettier check