### PR TITLE
Improve mining targeting and walk waypoints again

### DIFF
--- a/modules/mining/MiningBot.js
+++ b/modules/mining/MiningBot.js
@@ -4,11 +4,11 @@ import { MiningUtils } from '../../utils/MiningUtils';
 import { ModuleBase } from '../../utils/ModuleBase';
 import { NukerUtils } from '../../utils/NukerUtils';
 import { ClientboundLevelParticlesPacket } from '../../utils/Packets';
-import { Raytrace } from '../../utils/Raytrace';
+import { Raytrace, visibilityChecker } from '../../utils/Raytrace';
 import { manager } from '../../utils/SkyblockEvents';
 import { Utils } from '../../utils/Utils';
 import { Guis } from '../../utils/player/Inventory';
-import { Rotations } from '../../utils/player/Rotations';
+import { OreRotations } from '../../utils/player/OreRotations';
 import { ServerInfo } from '../../utils/player/ServerInfo';
 import { TabListUtils } from '../../utils/TabListUtils';
 import { Mouse } from '../../utils/Ungrab';
@@ -21,12 +21,12 @@ const ORTHO_FACE_AXES = {
 const FACE_FALLBACK_SAMPLES = [0, 0, 0.35, 0, -0.35, 0, 0, 0.35, 0, -0.35, 0.35, 0.35, -0.35, -0.35];
 const VISIBILITY_OFFSETS = [0, 0, 0, 0.18, 0, 0, -0.18, 0, 0, 0, 0, 0.18, 0, 0, -0.18];
 const VISIBILITY_SAMPLE_COUNT = VISIBILITY_OFFSETS.length / 3;
-const AIM_POINT_INSET = 0.48;
 const AIM_POINT_FACE_INSET = 0.48;
-const AIM_POINT_EDGE_MAG = 0.45;
+const AIM_POINT_EDGE_MAG = 0.4;
 const AIM_POINT_MID_CAP = 0.3;
 const AIM_POINT_LO = 0.02;
 const AIM_POINT_HI = 0.98;
+const VISIBLE_RAY_OFFSETS = [0.15, 0.5, 0.85];
 const TARGET_MODES = {
     REACHABLE: 'reachable',
     APPROACH: 'approach',
@@ -56,6 +56,9 @@ class Bot extends ModuleBase {
         this.SCAN_ONLY = false;
         this.DEBUG_MODE = false;
         this.ADDITIONAL_LAG_COMP = 0;
+        this.rotationSpeed = 0.48;
+        this.sneakWhileMining = true;
+        this.minimumVisibleRays = 0;
 
         this.STATES = { WAITING: 0, ABILITY: 1, MINING: 2, BUFF: 3, REFUEL: 4 };
 
@@ -240,10 +243,12 @@ class Bot extends ModuleBase {
             if (!this.enabled) return;
             if (this.refreshingMiningStats) {
                 this.stopMiningControls(true);
+                OreRotations.stop();
                 return;
             }
             if (Client.isInGui()) {
                 Client.unpressKeys();
+                OreRotations.stop();
                 return;
             }
 
@@ -301,10 +306,43 @@ class Bot extends ModuleBase {
             'Movement',
             (value) => {
                 this.MOVEMENT = value;
-                if (!value) Client.stopMovement();
+                if (!value) {
+                    Client.stopMovement();
+                    Client.setKey('space', false);
+                    Client.setKey('shift', false);
+                    this.lastSneakCommand = false;
+                }
             },
-            'Moves around vein while mining.',
+            'Moves toward visible ore only while it is outside normal mining reach.',
             true
+        );
+        this.addSlider(
+            'Block Reach',
+            3,
+            10,
+            8,
+            (value) => (this.approachScanReach = value),
+            'Maximum distance at which Movement can select an out-of-reach block to approach.'
+        );
+        this.addToggle(
+            'Sneak While Mining',
+            (value) => {
+                this.sneakWhileMining = value;
+                if (!value && this.enabled) {
+                    Client.setKey('shift', false);
+                    this.lastSneakCommand = false;
+                }
+            },
+            'Sneak while actively mining a block.',
+            true
+        );
+        this.addSlider(
+            'Minimum Visible Rays',
+            0,
+            9,
+            0,
+            (value) => (this.minimumVisibleRays = Math.round(value)),
+            'Minimum number of nine face samples that must raycast to the block. Zero accepts any visible amount.'
         );
         let additionalLagCompensation;
         this.addToggle(
@@ -350,6 +388,7 @@ class Bot extends ModuleBase {
             'Aims at the Precision Miner particle, speeds up mining mithril.',
             true
         );
+        this.addSlider('Mining Rotation Speed', 1, 100, 48, (value) => (this.rotationSpeed = value / 100), 'Rotation speed for mining targets.');
         this.addMultiToggle(
             'Fakelook',
             ['Off', 'Queued'],
@@ -545,6 +584,7 @@ class Bot extends ModuleBase {
         if (stopMovement) {
             Client.stopMovement();
             Client.setKey('space', false);
+            this.setSneak(false);
         }
         Client.setKey('leftclick', false);
     }
@@ -606,6 +646,9 @@ class Bot extends ModuleBase {
     handleAbilityState() {
         if (this.SCAN_ONLY) return (this.state = this.STATES.MINING);
 
+        this.stopMiningControls(true);
+        OreRotations.stop();
+
         const now = Date.now();
         const abilityStatus = TabListUtils.getPickaxeAbilityStatus();
 
@@ -644,7 +687,8 @@ class Bot extends ModuleBase {
 
         if (this.SCAN_ONLY) {
             this.scanForBlock(this.COSTTYPE);
-            if (this.MOVEMENT) this.stopMiningControls(true);
+            this.stopMiningControls(this.MOVEMENT);
+            OreRotations.stop();
             return;
         }
 
@@ -667,6 +711,8 @@ class Bot extends ModuleBase {
         const lowestCostBlock = this.currentTarget || this.foundLocations[this.lowestCostBlockIndex];
         if (!lowestCostBlock) {
             this.stopMiningControls(this.MOVEMENT);
+            this.setSneak(false);
+            OreRotations.stop();
             return;
         }
 
@@ -682,22 +728,24 @@ class Bot extends ModuleBase {
             this.foundLocations = [];
             this.lowestCostBlockIndex = 0;
             this.stopMiningControls(false);
+            this.setSneak(false);
+            OreRotations.stop();
             return;
         }
 
         const hasFreshAimPoint = this.refreshCurrentTargetAimPoint();
         if (!hasFreshAimPoint) {
             if (wasApproachTarget && this.MOVEMENT) {
-                this.allowScan = true;
                 this.handleVeinMovement();
 
                 const approachVector = this.getAimVectorForTarget(this.currentTarget);
-                if (approachVector) Rotations.lookAtVector(approachVector);
+                if (approachVector) OreRotations.trackVector(approachVector, this.rotationSpeed);
                 return;
             }
 
             this.movementReevalCooldownUntil = Math.max(this.movementReevalCooldownUntil, now + this.movementReevalCooldownMs);
             this.stopMiningControls(true);
+            OreRotations.stop();
             this.scanForBlock(this.COSTTYPE, this.currentTarget);
             this.allowScan = false;
             return;
@@ -722,15 +770,20 @@ class Bot extends ModuleBase {
 
         this.handleBreaking(blockName, fakeLookMode);
 
+        const timedOut = this.tickCount > this.totalTicks * 2;
         const shouldGlide = this.shouldGlideToNextBlock(blockName);
-        if (shouldGlide) {
+        if (timedOut && !this.isAirOrBedrock(blockName)) {
+            this.resetTickCounters();
+            this.currentTarget.aimX = this.currentTarget.aimY = this.currentTarget.aimZ = null;
+            this.refreshCurrentTargetAimPoint();
+        } else if (shouldGlide) {
             this.resetTickCounters();
             this.handleRotationOrScan(false);
         }
 
         const targetVector = this.getPrecisionMinerAim() || this.getAimVectorForTarget(this.currentTarget);
         if (this.currentTarget && targetVector) {
-            Rotations.lookAtVector(targetVector);
+            OreRotations.trackVector(targetVector, this.rotationSpeed);
         }
     }
 
@@ -915,14 +968,16 @@ class Bot extends ModuleBase {
         let evaluatedCount = 0;
 
         for (const candidate of sortedCandidates) {
-            if (evaluatedCount >= this.reachableCandidateEvaluationBudget && visibleTargets.length >= this.reachableVisibleStopCount) {
+            if (
+                evaluatedCount >= this.reachableCandidateEvaluationBudget &&
+                (visibleTargets.length >= this.reachableVisibleStopCount || evaluatedCount >= this.reachableCandidateEvaluationBudget * 3)
+            )
                 break;
-            }
 
             evaluatedCount++;
 
             const aimData = this.findVisibleAimPoint(candidate.x, candidate.y, candidate.z, eyePos, lookVec, maxReachSq, checkFov);
-            if (!aimData) continue;
+            if (!aimData || !this.hasMinimumVisibleRays(candidate, aimData, eyePos)) continue;
 
             const baseCost = this.calculateBlockCost(candidate.targetCost, aimData.dist, aimData.dot);
             const visibilityStability = this.calculateVisibilityStability(candidate.x, candidate.y, candidate.z, eyePos, maxReachSq, 1);
@@ -963,7 +1018,27 @@ class Bot extends ModuleBase {
 
         let found = this.evaluateReachableCandidates(scanned.reachableCandidates, eyePos, lookVec, mineReachSq);
         if (found.length === 0 && allowApproachTargets) {
-            found = this.collectScanTargets(targetCosts, eyePos, lookVec, this.approachScanReach, excludedBlock, false, true).approachTargets;
+            found = this.collectScanTargets(targetCosts, eyePos, lookVec, this.approachScanReach, excludedBlock, false, true)
+                .approachTargets.map((candidate) => {
+                    const aim = this.findVisibleAimPoint(candidate.x, candidate.y, candidate.z, eyePos, lookVec, this.approachScanReach ** 2, false);
+                    if (!aim) return null;
+
+                    const visibleRays = this.minimumVisibleRays > 0 ? this.countVisibleRays(candidate, aim, eyePos) : 9;
+                    return {
+                        ...candidate,
+                        aimX: aim.x,
+                        aimY: aim.y,
+                        aimZ: aim.z,
+                        dist: aim.dist,
+                        visibleRays,
+                    };
+                })
+                .filter(Boolean);
+
+            const approachTarget = found[0];
+            if (approachTarget && approachTarget.visibleRays < this.minimumVisibleRays) {
+                approachTarget.visibilityStrafeKey = this.findVisibilityStrafeKey(approachTarget, eyePos, approachTarget.visibleRays);
+            }
         }
 
         if (found.length > 0) {
@@ -993,6 +1068,7 @@ class Bot extends ModuleBase {
         const eyeX = eyePos.x(),
             eyeY = eyePos.y(),
             eyeZ = eyePos.z();
+        const rayEye = { x: eyeX, y: eyeY, z: eyeZ };
         const vx = cx - eyeX,
             vy = cy - eyeY,
             vz = cz - eyeZ;
@@ -1098,61 +1174,37 @@ class Bot extends ModuleBase {
                     } else if (sampleIndex === 3) {
                         v = vEdge;
                     }
-                    let tx;
-                    let ty;
-                    let tz;
                     let fx;
                     let fy;
                     let fz;
 
                     if (isX) {
-                        tx = cx + localS * AIM_POINT_INSET;
-                        ty = cy + u;
-                        tz = cz + v;
                         fx = cx + localS * AIM_POINT_FACE_INSET;
-                        fy = ty;
-                        fz = tz;
-                        if (ty < y + AIM_POINT_LO) ty = y + AIM_POINT_LO;
-                        else if (ty > y + AIM_POINT_HI) ty = y + AIM_POINT_HI;
-                        if (tz < z + AIM_POINT_LO) tz = z + AIM_POINT_LO;
-                        else if (tz > z + AIM_POINT_HI) tz = z + AIM_POINT_HI;
+                        fy = cy + u;
+                        fz = cz + v;
                         if (fy < y + AIM_POINT_LO) fy = y + AIM_POINT_LO;
                         else if (fy > y + AIM_POINT_HI) fy = y + AIM_POINT_HI;
                         if (fz < z + AIM_POINT_LO) fz = z + AIM_POINT_LO;
                         else if (fz > z + AIM_POINT_HI) fz = z + AIM_POINT_HI;
                     } else if (isY) {
-                        tx = cx + u;
-                        ty = cy + localS * AIM_POINT_INSET;
-                        tz = cz + v;
-                        fx = tx;
+                        fx = cx + u;
                         fy = cy + localS * AIM_POINT_FACE_INSET;
-                        fz = tz;
-                        if (tx < x + AIM_POINT_LO) tx = x + AIM_POINT_LO;
-                        else if (tx > x + AIM_POINT_HI) tx = x + AIM_POINT_HI;
-                        if (tz < z + AIM_POINT_LO) tz = z + AIM_POINT_LO;
-                        else if (tz > z + AIM_POINT_HI) tz = z + AIM_POINT_HI;
+                        fz = cz + v;
                         if (fx < x + AIM_POINT_LO) fx = x + AIM_POINT_LO;
                         else if (fx > x + AIM_POINT_HI) fx = x + AIM_POINT_HI;
                         if (fz < z + AIM_POINT_LO) fz = z + AIM_POINT_LO;
                         else if (fz > z + AIM_POINT_HI) fz = z + AIM_POINT_HI;
                     } else {
-                        tx = cx + u;
-                        ty = cy + v;
-                        tz = cz + localS * AIM_POINT_INSET;
-                        fx = tx;
-                        fy = ty;
+                        fx = cx + u;
+                        fy = cy + v;
                         fz = cz + localS * AIM_POINT_FACE_INSET;
-                        if (tx < x + AIM_POINT_LO) tx = x + AIM_POINT_LO;
-                        else if (tx > x + AIM_POINT_HI) tx = x + AIM_POINT_HI;
-                        if (ty < y + AIM_POINT_LO) ty = y + AIM_POINT_LO;
-                        else if (ty > y + AIM_POINT_HI) ty = y + AIM_POINT_HI;
                         if (fx < x + AIM_POINT_LO) fx = x + AIM_POINT_LO;
                         else if (fx > x + AIM_POINT_HI) fx = x + AIM_POINT_HI;
                         if (fy < y + AIM_POINT_LO) fy = y + AIM_POINT_LO;
                         else if (fy > y + AIM_POINT_HI) fy = y + AIM_POINT_HI;
                     }
 
-                    if (Raytrace.isLineClear(eyeX, eyeY, eyeZ, tx, ty, tz, x, y, z)) {
+                    if (Raytrace.isLineClear(eyeX, eyeY, eyeZ, fx, fy, fz, x, y, z) && visibilityChecker.testPointNative(x, y, z, [fx, fy, fz], rayEye)) {
                         resultX = fx;
                         resultY = fy;
                         resultZ = fz;
@@ -1163,61 +1215,37 @@ class Bot extends ModuleBase {
                 for (let sampleIndex = 0; sampleIndex < FACE_FALLBACK_SAMPLES.length && !found; sampleIndex += 2) {
                     const u = FACE_FALLBACK_SAMPLES[sampleIndex];
                     const v = FACE_FALLBACK_SAMPLES[sampleIndex + 1];
-                    let tx;
-                    let ty;
-                    let tz;
                     let fx;
                     let fy;
                     let fz;
 
                     if (isX) {
-                        tx = cx + localS * AIM_POINT_INSET;
-                        ty = cy + u;
-                        tz = cz + v;
                         fx = cx + localS * AIM_POINT_FACE_INSET;
                         fy = cy + u;
                         fz = cz + v;
-                        if (ty < y + AIM_POINT_LO) ty = y + AIM_POINT_LO;
-                        else if (ty > y + AIM_POINT_HI) ty = y + AIM_POINT_HI;
-                        if (tz < z + AIM_POINT_LO) tz = z + AIM_POINT_LO;
-                        else if (tz > z + AIM_POINT_HI) tz = z + AIM_POINT_HI;
                         if (fy < y + AIM_POINT_LO) fy = y + AIM_POINT_LO;
                         else if (fy > y + AIM_POINT_HI) fy = y + AIM_POINT_HI;
                         if (fz < z + AIM_POINT_LO) fz = z + AIM_POINT_LO;
                         else if (fz > z + AIM_POINT_HI) fz = z + AIM_POINT_HI;
                     } else if (isY) {
-                        ty = cy + localS * AIM_POINT_INSET;
-                        tx = cx + u;
-                        tz = cz + v;
                         fy = cy + localS * AIM_POINT_FACE_INSET;
                         fx = cx + u;
                         fz = cz + v;
-                        if (tx < x + AIM_POINT_LO) tx = x + AIM_POINT_LO;
-                        else if (tx > x + AIM_POINT_HI) tx = x + AIM_POINT_HI;
-                        if (tz < z + AIM_POINT_LO) tz = z + AIM_POINT_LO;
-                        else if (tz > z + AIM_POINT_HI) tz = z + AIM_POINT_HI;
                         if (fx < x + AIM_POINT_LO) fx = x + AIM_POINT_LO;
                         else if (fx > x + AIM_POINT_HI) fx = x + AIM_POINT_HI;
                         if (fz < z + AIM_POINT_LO) fz = z + AIM_POINT_LO;
                         else if (fz > z + AIM_POINT_HI) fz = z + AIM_POINT_HI;
                     } else {
-                        tz = cz + localS * AIM_POINT_INSET;
-                        tx = cx + u;
-                        ty = cy + v;
                         fz = cz + localS * AIM_POINT_FACE_INSET;
                         fx = cx + u;
                         fy = cy + v;
-                        if (tx < x + AIM_POINT_LO) tx = x + AIM_POINT_LO;
-                        else if (tx > x + AIM_POINT_HI) tx = x + AIM_POINT_HI;
-                        if (ty < y + AIM_POINT_LO) ty = y + AIM_POINT_LO;
-                        else if (ty > y + AIM_POINT_HI) ty = y + AIM_POINT_HI;
                         if (fx < x + AIM_POINT_LO) fx = x + AIM_POINT_LO;
                         else if (fx > x + AIM_POINT_HI) fx = x + AIM_POINT_HI;
                         if (fy < y + AIM_POINT_LO) fy = y + AIM_POINT_LO;
                         else if (fy > y + AIM_POINT_HI) fy = y + AIM_POINT_HI;
                     }
 
-                    if (Raytrace.isLineClear(eyeX, eyeY, eyeZ, tx, ty, tz, x, y, z)) {
+                    if (Raytrace.isLineClear(eyeX, eyeY, eyeZ, fx, fy, fz, x, y, z) && visibilityChecker.testPointNative(x, y, z, [fx, fy, fz], rayEye)) {
                         resultX = fx;
                         resultY = fy;
                         resultZ = fz;
@@ -1270,27 +1298,59 @@ class Bot extends ModuleBase {
         return visibleSamples / VISIBILITY_SAMPLE_COUNT;
     }
 
-    isTargetDirectlyUnderPlayer(target = this.currentTarget) {
-        if (!target) return false;
+    countVisibleRays(block, aim, eyePosition, stopAt = Infinity) {
+        const eye = { x: eyePosition.x(), y: eyePosition.y(), z: eyePosition.z() };
+        const origin = [block.x, block.y, block.z];
+        const local = [aim.x - block.x, aim.y - block.y, aim.z - block.z];
+        const edgeDistances = local.map((value) => Math.min(value, 1 - value));
+        const faceAxis = edgeDistances.indexOf(Math.min(...edgeDistances));
+        const faceOffset = local[faceAxis] < 0.5 ? AIM_POINT_LO : AIM_POINT_HI;
+        const sampleAxes = [0, 1, 2].filter((axis) => axis !== faceAxis);
+        let visibleRays = 0;
 
-        const playerBlockX = Math.floor(Player.getX());
-        const playerBlockY = Math.floor(Player.getY());
-        const playerBlockZ = Math.floor(Player.getZ());
-
-        return target.x === playerBlockX && target.z === playerBlockZ && target.y <= playerBlockY - 1;
+        for (const firstOffset of VISIBLE_RAY_OFFSETS) {
+            for (const secondOffset of VISIBLE_RAY_OFFSETS) {
+                const point = [block.x + 0.5, block.y + 0.5, block.z + 0.5];
+                point[faceAxis] = origin[faceAxis] + faceOffset;
+                point[sampleAxes[0]] = origin[sampleAxes[0]] + firstOffset;
+                point[sampleAxes[1]] = origin[sampleAxes[1]] + secondOffset;
+                if (visibilityChecker.testPointCustom(block.x, block.y, block.z, point, eye) && ++visibleRays >= stopAt) return visibleRays;
+            }
+        }
+        return visibleRays;
     }
 
-    isTargetAbovePlayer(target = this.currentTarget, minUpwardPitchDeg = 60) {
-        if (!target) return false;
+    hasMinimumVisibleRays(block, aim, eyePosition) {
+        return this.minimumVisibleRays <= 0 || this.countVisibleRays(block, aim, eyePosition, this.minimumVisibleRays) >= this.minimumVisibleRays;
+    }
 
-        const targetPoint = {
-            x: target.aimX ?? target.x + 0.5,
-            y: target.aimY ?? target.y + 0.5,
-            z: target.aimZ ?? target.z + 0.5,
-        };
-        const { pitch } = MathUtils.calculateAbsoluteAngles(targetPoint);
+    findVisibilityStrafeKey(block, eyePosition, currentRays) {
+        const dx = block.x + 0.5 - eyePosition.x();
+        const dz = block.z + 0.5 - eyePosition.z();
+        const distance = Math.hypot(dx, dz);
+        if (distance < 0.001) return null;
 
-        return pitch <= -Math.abs(minUpwardPitchDeg);
+        const leftX = dz / distance;
+        const leftZ = -dx / distance;
+        let bestKey = null;
+        let bestRays = currentRays;
+
+        for (const [key, direction] of [
+            ['a', 1],
+            ['d', -1],
+        ]) {
+            const candidateEye = new Vec3d(eyePosition.x() + leftX * direction * 0.75, eyePosition.y(), eyePosition.z() + leftZ * direction * 0.75);
+            const aim = this.findVisibleAimPoint(block.x, block.y, block.z, candidateEye, null, this.approachScanReach ** 2, false);
+            if (!aim) continue;
+
+            const visibleRays = this.countVisibleRays(block, aim, candidateEye);
+            if (visibleRays > bestRays) {
+                bestKey = key;
+                bestRays = visibleRays;
+            }
+        }
+
+        return bestKey;
     }
 
     setSneak(shouldSneak, force = false) {
@@ -1301,9 +1361,17 @@ class Bot extends ModuleBase {
     }
 
     handleVeinMovement() {
-        if (!this.MOVEMENT || !this.currentTarget) {
+        if (!this.currentTarget) {
             Client.stopMovement();
             Client.setKey('space', false);
+            this.setSneak(false);
+            return;
+        }
+
+        if (!this.MOVEMENT) {
+            Client.stopMovement();
+            Client.setKey('space', false);
+            this.setSneak(this.sneakWhileMining);
             return;
         }
 
@@ -1314,65 +1382,40 @@ class Bot extends ModuleBase {
         };
 
         const values = MathUtils.getDistanceToPlayerEyes(targetPoint);
-        const yaw = MathUtils.calculateAngles(targetPoint).yaw;
+        const aligned = Math.abs(MathUtils.calculateAngles(targetPoint).yaw) <= 18;
 
-        if (!this._movementHumanizer) {
-            this._movementHumanizer = {
-                strafeThreshold: 15,
-                stopYawThreshold: 10,
-                moveInMin: 1.5,
-                moveInMax: 3.0,
-                moveOutThreshold: 3.75,
-                unsneakLargeMoveThreshold: 5.5,
-                unsneakDropYThreshold: 0.5,
-                jumpReachPadding: 0.2,
-            };
-        }
-
-        const cfg = this._movementHumanizer;
-        const tunnelMode = this.isTunnelMode();
-        const isHighTarget = this.isTargetAbovePlayer(this.currentTarget);
-        if (this.isTargetDirectlyUnderPlayer(this.currentTarget) || (!tunnelMode && isHighTarget)) {
+        if (!this.isApproachTarget()) {
             Client.stopMovement();
-            this.setSneak(true);
             Client.setKey('space', false);
+            this.setSneak(this.sneakWhileMining);
             return;
         }
 
-        let moveRight = yaw > cfg.strafeThreshold;
-        let moveLeft = yaw < -cfg.strafeThreshold;
-        let moveForward = values.distanceFlat > cfg.moveInMax;
-        let moveBack = values.distanceFlat < cfg.moveInMin;
-
-        const isAligned =
-            yaw >= -cfg.stopYawThreshold &&
-            yaw <= cfg.stopYawThreshold &&
-            values.distance <= 4 &&
-            !(tunnelMode && isHighTarget && values.distanceFlat < cfg.moveInMin);
-        const inDistanceBand = values.distanceFlat >= 2.5 && values.distanceFlat <= 3.25;
-        if (isAligned || inDistanceBand) {
-            moveRight = false;
-            moveLeft = false;
-            moveForward = false;
-            moveBack = false;
+        const visibilityStrafeKey = this.currentTarget.visibilityStrafeKey;
+        if (visibilityStrafeKey && values.distance <= this.mineReach) {
+            const strafeTicks = this.currentTarget.visibilityStrafeTicks ?? 0;
+            Client.setKey('a', aligned && strafeTicks < 20 && visibilityStrafeKey === 'a');
+            Client.setKey('d', aligned && strafeTicks < 20 && visibilityStrafeKey === 'd');
+            Client.setKey('w', false);
+            Client.setKey('s', false);
+            Client.setKey('space', false);
+            this.setSneak(this.sneakWhileMining);
+            if (!aligned) return;
+            if (strafeTicks < 20) {
+                this.currentTarget.visibilityStrafeTicks = strafeTicks + 1;
+                return;
+            }
+            this.currentTarget.visibilityStrafeKey = null;
         }
 
-        Client.setKey('d', moveRight);
-        Client.setKey('a', moveLeft);
-        Client.setKey('w', moveForward);
-        Client.setKey('s', moveBack);
+        Client.setKey('a', false);
+        Client.setKey('d', false);
+        Client.setKey('w', aligned);
+        Client.setKey('s', false);
 
-        const isMoving = moveRight || moveLeft || moveForward || moveBack;
-        const playerFeetY = Player.getY();
-        const targetTopY = this.currentTarget.y + 1;
-        const dropAmount = playerFeetY - targetTopY;
-        const requiresDropToMove = dropAmount > cfg.unsneakDropYThreshold && values.distanceFlat > 0.35;
-        const requiresLargeMove = values.distanceFlat > cfg.unsneakLargeMoveThreshold;
-        const justOutOfReach = true; //values.distance > this.mineReach && values.distance <= this.mineReach + cfg.jumpReachPadding;
-        const blockedForward = moveForward && this.hasForwardObstacle();
-        const shouldJump = Player.getPlayer()?.onGround() && justOutOfReach && blockedForward;
-        const shouldUnsneak = isMoving && (requiresDropToMove || requiresLargeMove);
-        this.setSneak(!shouldUnsneak);
+        const blockedForward = aligned && this.hasForwardObstacle();
+        const shouldJump = Player.getPlayer()?.onGround() && blockedForward && this.currentTarget.y >= Math.floor(Player.getY());
+        this.setSneak(this.sneakWhileMining);
         Client.setKey('space', shouldJump);
     }
 
@@ -1380,6 +1423,19 @@ class Bot extends ModuleBase {
         if (!this.currentTarget) return false;
 
         const eyePos = Player.getPlayer().getEyePosition();
+        if (
+            this.isCurrentAimPointVisible(eyePos) &&
+            (!this.isApproachTarget() ||
+                this.hasMinimumVisibleRays(this.currentTarget, { x: this.currentTarget.aimX, y: this.currentTarget.aimY, z: this.currentTarget.aimZ }, eyePos))
+        ) {
+            const dx = this.currentTarget.aimX - eyePos.x();
+            const dy = this.currentTarget.aimY - eyePos.y();
+            const dz = this.currentTarget.aimZ - eyePos.z();
+            this.currentTarget.dist = Math.hypot(dx, dy, dz);
+            this.currentTarget.targetMode = TARGET_MODES.REACHABLE;
+            return true;
+        }
+
         const lookVec = Player.asPlayerMP().getLookVector();
         const hit = this.findVisibleAimPoint(
             this.currentTarget.x,
@@ -1391,7 +1447,7 @@ class Bot extends ModuleBase {
             false
         );
 
-        if (!hit) return false;
+        if (!hit || !this.hasMinimumVisibleRays(this.currentTarget, hit, eyePos)) return false;
 
         this.currentTarget.aimX = hit.x;
         this.currentTarget.aimY = hit.y;
@@ -1399,6 +1455,22 @@ class Bot extends ModuleBase {
         this.currentTarget.dist = hit.dist;
         this.currentTarget.targetMode = TARGET_MODES.REACHABLE;
         return true;
+    }
+
+    isCurrentAimPointVisible(eyePos) {
+        const target = this.currentTarget;
+        if (!target || !eyePos || ![target.aimX, target.aimY, target.aimZ].every(Number.isFinite)) return false;
+
+        const dx = target.aimX - eyePos.x();
+        const dy = target.aimY - eyePos.y();
+        const dz = target.aimZ - eyePos.z();
+        if (dx * dx + dy * dy + dz * dz > this.faceReach * this.faceReach) return false;
+
+        return visibilityChecker.testPointNative(target.x, target.y, target.z, [target.aimX, target.aimY, target.aimZ], {
+            x: eyePos.x(),
+            y: eyePos.y(),
+            z: eyePos.z(),
+        });
     }
 
     getAimVectorForTarget(target) {
@@ -1448,13 +1520,14 @@ class Bot extends ModuleBase {
         this.manualScan = true;
 
         const eyePos = Player.getPlayer().getEyePosition();
+        const lookVec = Player.asPlayerMP().getLookVector();
         const maxReachSq = this.mineReach * this.mineReach;
 
         this.foundLocations = locations
             .map((loc) => {
-                const hit = this.findVisibleAimPoint(loc.x, loc.y, loc.z, eyePos, null, maxReachSq, false);
+                const hit = this.findVisibleAimPoint(loc.x, loc.y, loc.z, eyePos, lookVec, maxReachSq, false);
 
-                if (!hit) return null;
+                if (!hit || !this.hasMinimumVisibleRays(loc, hit, eyePos)) return null;
 
                 return {
                     x: loc.x,
@@ -1543,13 +1616,12 @@ class Bot extends ModuleBase {
         this.mineTickCount = 0;
         this.tickCount = 0;
         this.movementReevalCooldownUntil = 0;
-        this._movementHumanizer = null;
         this.lastRenderFrameTime = null;
         this.lastRenderPos = null;
         this.lastAimPos = null;
         this.lastNextPos = null;
         this.precisionMinerAim = null;
-        Rotations.stop();
+        OreRotations.stop();
         this.normalRender.unregister();
     }
 

--- a/modules/mining/OreMacro.js
+++ b/modules/mining/OreMacro.js
@@ -104,6 +104,7 @@ class OreMiner extends ModuleBase {
         this.etherwarpRayCursor = 0;
         this.mineRetries = 0;
         this.currentBlockName = '';
+        this.currentMineAim = null;
         this.strafeKey = null;
         this.mineStrafeTarget = null;
         this.etherwarpStrafeAligned = false;
@@ -596,6 +597,7 @@ class OreMiner extends ModuleBase {
         this.abilityUseReadyAt = 0;
         this.currentRenderTarget = null;
         this.nextRenderTarget = null;
+        this.currentMineAim = null;
         this.typeMineBlock = null;
         this.typeMineNextBlock = null;
         this.typeMineIgnored = {};
@@ -612,6 +614,7 @@ class OreMiner extends ModuleBase {
         OreRotations.stop();
         this.currentRenderTarget = null;
         this.nextRenderTarget = null;
+        this.currentMineAim = null;
         this.typeMineBlock = null;
         this.typeMineNextBlock = null;
         this.typeMineIgnored = {};
@@ -749,10 +752,10 @@ class OreMiner extends ModuleBase {
                 this.typeMineBlock = null;
                 this.typeMineNextBlock = null;
                 this.typeMineIgnored = {};
-                Client.setKey('leftclick', false);
-                if (!this.typeMineEnabled && waypoint.isDeployable && this.deployableWaypointsEnabled && !this.hasNearbyDeployable(waypoint.pos))
+                if (!this.typeMineEnabled && waypoint.isDeployable && this.deployableWaypointsEnabled && !this.hasNearbyDeployable(waypoint.pos)) {
+                    Client.setKey('leftclick', false);
                     this.enterState('DEPLOYABLE');
-                else {
+                } else {
                     Guis.setItemSlot(this.drillSlot);
                     Client.setKey('leftclick', true);
                     this.enterState('MINE_NEXT');
@@ -765,9 +768,28 @@ class OreMiner extends ModuleBase {
             case 'MINE_STRAFE':
                 return this.tickMineStrafe(waypoint);
 
-            case 'MINE_WAIT_ROTATION':
-                if (!OreRotations.isRotating || ++this.waitTicks >= 60) this.beginMiningAction(waypoint);
+            case 'MINE_WAIT_ROTATION': {
+                const block = this.getCurrentMineBlock(waypoint);
+                if (!block || this.shouldSkipBlock(block)) {
+                    this.enterState('MINE_NEXT');
+                    return;
+                }
+                if (this.trackCurrentMineBlock(waypoint, this.waitTicks % 3 === 0)) {
+                    this.beginMiningAction(waypoint);
+                } else if (++this.waitTicks >= 60) {
+                    this.currentMineAim = null;
+                    const aim = this.getMineAim(block, true);
+                    if (aim) {
+                        this.currentMineAim = aim;
+                        OreRotations.trackVector(aim, this.oreMineSpeed);
+                        this.waitTicks = 0;
+                    } else if (!this.handleUnreachableBlock(block)) {
+                        this.finishMineBlock(true);
+                        this.enterState('MINE_NEXT');
+                    }
+                }
                 return;
+            }
 
             case 'MINE_ONETAP':
                 if (++this.waitTicks >= 2) {
@@ -786,6 +808,7 @@ class OreMiner extends ModuleBase {
                 this.typeMineBlock = null;
                 this.typeMineNextBlock = null;
                 this.typeMineIgnored = {};
+                this.currentMineAim = null;
                 Client.setKey('leftclick', false);
                 Client.stopMovement();
                 this.enterState('WAYPOINT');
@@ -920,10 +943,10 @@ class OreMiner extends ModuleBase {
 
     tickWalk(waypoint) {
         const { x, y, z } = waypoint.pos;
-        const dx = Player.getX() - (x + 0.5);
+        const dx = Player.getX() - x;
         const dy = Player.getY() - y;
-        const dz = Player.getZ() - (z + 0.5);
-        const atWaypoint = dx * dx + dz * dz <= 0.5 && Math.abs(dy) <= 2;
+        const dz = Player.getZ() - z;
+        const atWaypoint = dx * dx + dz * dz <= 0.6 && Math.abs(dy) <= 2;
 
         if (atWaypoint) {
             const hasAction = this.typeMineEnabled || waypoint.minableBlocks.length > 0 || (waypoint.isDeployable && this.deployableWaypointsEnabled);
@@ -948,7 +971,6 @@ class OreMiner extends ModuleBase {
 
             Keybind.stopMovement();
             Keybind.setKey('shift', false);
-            OreRotations.stop();
             this.enterState('MINE_INIT');
             return;
         }
@@ -956,9 +978,15 @@ class OreMiner extends ModuleBase {
         const previousWaypoint = this.loadedWaypoints[(this.waypointIndex - 1 + this.loadedWaypoints.length) % this.loadedWaypoints.length];
         const intentionalDrop = previousWaypoint?.pos?.y > y;
         const nearEdge = !intentionalDrop && this.hasEdgeAhead(x, y, z);
-        Keybind.setKeysForStraightLineCoords(x + 0.5, y, z + 0.5, !nearEdge);
-        Keybind.setKey('shift', nearEdge);
-        Keybind.setKey('sprint', !nearEdge && dx * dx + dz * dz > 2);
+        if (nearEdge) {
+            this.ensureShiftHeld();
+            if (Player.isSneaking()) Keybind.setKeysForStraightLineCoords(x, y, z, false);
+            else Keybind.stopMovement();
+        } else {
+            Keybind.setKey('shift', false);
+            Keybind.setKeysForStraightLineCoords(x, y, z, true);
+        }
+        Keybind.setKey('sprint', false);
         this.waitTicks++;
         this.updateWalkWaypointLookAhead();
         if (this.waitTicks >= 300) {
@@ -977,23 +1005,22 @@ class OreMiner extends ModuleBase {
 
         if (target.walkGuide) {
             Client.setKey('leftclick', false);
-            if (MathUtils.angleToPlayer(target.vector).distance <= 15) {
+            const distance = MathUtils.distanceToPlayerPoint(target.vector);
+            const looseTolerance = Math.min(10, (Math.atan2(0.5, Math.max(1, distance)) * 180) / Math.PI);
+            if (MathUtils.angleToPlayer(target.vector).distance <= looseTolerance) {
                 OreRotations.stop();
                 return true;
             }
-            if (this.waitTicks === 0) {
-                OreRotations.stop();
-                return OreRotations.lookAtVector(target.vector, this.oreMineSpeed);
-            }
-            return true;
+            return OreRotations.trackVector(target.vector, this.oreMineSpeed);
         }
 
         const distance = MathUtils.distanceToPlayerPoint(target.vector);
         if (target.block && distance <= 5) {
             const aim = this.getMineAim(target.block, this.waitTicks % 3 === 0);
             if (aim) {
+                this.currentMineAim = aim;
                 const canHoldMine = !target.block.oneTap && !target.block.rOneTap;
-                if (this.sneakWhileMining && target.sneakMine && canHoldMine) {
+                if (target.sneakMine && canHoldMine) {
                     this.ensureShiftHeld();
                     Keybind.setKey('shift', true);
                     if (!Player.isSneaking()) {
@@ -1002,13 +1029,15 @@ class OreMiner extends ModuleBase {
                     }
                 }
                 if (canHoldMine && Player.getHeldItemIndex() !== this.drillSlot) Guis.setItemSlot(this.drillSlot);
-                Client.setKey('leftclick', canHoldMine);
+                Client.setKey('leftclick', canHoldMine && this.isCrosshairOnBlock(target.block));
                 return OreRotations.trackVector(aim, this.oreMineSpeed);
             }
         }
 
         Client.setKey('leftclick', false);
-        const looseTolerance = (Math.atan2(1.5, Math.max(1, distance)) * 180) / Math.PI;
+        if (target.block) return OreRotations.trackVector(target.vector, this.oreMineSpeed);
+
+        const looseTolerance = Math.min(10, (Math.atan2(0.5, Math.max(1, distance)) * 180) / Math.PI);
         if (MathUtils.angleToPlayer(target.vector).distance <= looseTolerance) {
             OreRotations.stop();
             return true;
@@ -1133,7 +1162,7 @@ class OreMiner extends ModuleBase {
         const aim = this.getMineAim(block, this.waitTicks % 3 === 0);
         if (aim) {
             this.stopMiningStrafe(false, false);
-            this.prepareBlock(block, aim, true);
+            this.prepareBlock(block, aim);
             return;
         }
         if (!this.mineStrafeTarget) {
@@ -1165,7 +1194,7 @@ class OreMiner extends ModuleBase {
 
     handleUnreachableBlock(block) {
         if (!this.miningStrafing) return false;
-        Client.setKey('leftclick', false);
+        Client.setKey('leftclick', !block.oneTap && !block.rOneTap);
         this.mineStrafeTarget = null;
         this.strafedForBlock = true;
         this.ensureShiftHeld();
@@ -1173,15 +1202,14 @@ class OreMiner extends ModuleBase {
         return true;
     }
 
-    prepareBlock(block, aim, continueRotation = false) {
+    prepareBlock(block, aim) {
         this.currentBlockName = this.getBlockName(block);
         this.currentRenderTarget = { x: block.x, y: block.y, z: block.z };
         this.nextRenderTarget = this.findNextMineTarget(this.mineIndex + 1);
         this.mineRetries = 0;
-        if (block.oneTap || block.rOneTap) Client.setKey('leftclick', false);
-        else Client.setKey('leftclick', true);
-        if (continueRotation) OreRotations.retargetVector(aim, this.oreMineSpeed);
-        else OreRotations.lookAtVector(aim, this.oreMineSpeed);
+        this.currentMineAim = aim;
+        Client.setKey('leftclick', !block.oneTap && !block.rOneTap);
+        OreRotations.trackVector(aim, this.oreMineSpeed);
         this.enterState('MINE_WAIT_ROTATION');
     }
 
@@ -1223,6 +1251,7 @@ class OreMiner extends ModuleBase {
             return;
         }
 
+        this.trackCurrentMineBlock(waypoint, this.waitTicks % 3 === 0);
         Client.setKey('leftclick', true);
         if (++this.waitTicks < this.mineTimeoutTicks) return;
 
@@ -1240,7 +1269,8 @@ class OreMiner extends ModuleBase {
             this.enterState('MINE_NEXT');
             return;
         }
-        OreRotations.lookAtVector(aim, this.oreMineSpeed);
+        this.currentMineAim = aim;
+        OreRotations.trackVector(aim, this.oreMineSpeed);
         this.enterState('MINE_WAIT_ROTATION');
     }
 
@@ -1564,13 +1594,15 @@ class OreMiner extends ModuleBase {
         const lookLength = lookVec ? Math.hypot(lookVec.x(), lookVec.z()) : 0;
         const minimumFovDot = Math.cos((this.typeMineFov * Math.PI) / 360);
         for (const candidate of candidates) {
+            if (this.typeMineIgnored[this.mineBlockKey(candidate)]) continue;
+
             const dx = candidate.x + 0.5 - eyePos.x();
             const dz = candidate.z + 0.5 - eyePos.z();
             const horizontalDistance = Math.hypot(dx, dz);
             const lookDot = lookLength && horizontalDistance ? (dx * lookVec.x() + dz * lookVec.z()) / (horizontalDistance * lookLength) : 1;
             if (this.typeMineFov < 360 && lookDot < minimumFovDot) continue;
             const aim = this.getMineAim(candidate);
-            if (this.typeMineIgnored[this.mineBlockKey(candidate)] || !aim || !this.hasMinimumTypeMineVisibility(candidate, aim, eyePos)) continue;
+            if (!aim || !this.hasMinimumTypeMineVisibility(candidate, aim, eyePos)) continue;
             targets.push(candidate);
             if (targets.length >= 3) break;
         }
@@ -1611,6 +1643,15 @@ class OreMiner extends ModuleBase {
         return this.typeMineEnabled ? this.typeMineBlock : waypoint.minableBlocks[this.mineIndex];
     }
 
+    trackCurrentMineBlock(waypoint, thorough = false) {
+        const block = this.getCurrentMineBlock(waypoint);
+        if (!block || this.shouldSkipBlock(block)) return false;
+
+        if (!this.currentMineAim) this.currentMineAim = this.getMineAim(block, thorough);
+        if (this.currentMineAim) OreRotations.trackVector(this.currentMineAim, this.oreMineSpeed);
+        return this.isCrosshairOnBlock(block);
+    }
+
     finishMineBlock(ignore = false) {
         if (!this.typeMineEnabled) {
             this.mineIndex++;
@@ -1623,6 +1664,11 @@ class OreMiner extends ModuleBase {
 
     mineBlockKey(block) {
         return `${block.x},${block.y},${block.z}`;
+    }
+
+    isCrosshairOnBlock(block) {
+        const pos = block && Raytrace.getLookingAt(5)?.getPos?.();
+        return !!pos && pos.getX() === block.x && pos.getY() === block.y && pos.getZ() === block.z;
     }
 
     shouldSneakForMineBlock(block, waypoint = this.loadedWaypoints?.[this.waypointIndex]) {

--- a/utils/Raytrace.js
+++ b/utils/Raytrace.js
@@ -17,8 +17,6 @@ class VisibilityChecker {
     generateFaceOffsets() {
         let offsets = [];
 
-        offsets.push([0.5, 0.5, 0.5]);
-
         let faceConfigs = [
             { axis: 0, value: 0.05, otherAxes: [1, 2] },
             { axis: 0, value: 0.95, otherAxes: [1, 2] },


### PR DESCRIPTION
**Summary:**
Improved Mining Bot and Ore Macro targeting reliability, rotation behavior, and movement around mining targets.

**Changes:**
- Uses `OreRotations` for Mining Bot aiming.
- Adds Mining Bot settings for rotation speed, sneak while mining, minimum visible rays, and block approach reach.
- Reworks Mining Bot movement to approach out-of-reach blocks without constantly repositioning.
- Forces Mining Bot to select a fresh aim point when mining times out.
- Keeps Ore Macro rotations continuously tracking the intended block.
- Verifies the crosshair is actually targeting the expected block before considering a rotation complete.
- Improves Walk waypoint arrival and continuous pre-aim behavior.
- Preserves rotation continuity when transitioning from walking or strafing into mining.
- Uses safer inward target points to reduce edge-ray misses.
- Removes the unsafe center-ray visibility fallback.

**Tested in game and working!**