### PR TITLE
PowderNuker: restore mining tool after refuel

### DIFF
--- a/modules/mining/PowderNuker.js
+++ b/modules/mining/PowderNuker.js
@@ -7,6 +7,7 @@ import { TabListUtils } from '../../utils/TabListUtils';
 import { manager } from '../../utils/SkyblockEvents';
 import { Nuker } from './Nuker';
 import { MiningUtils } from '../../utils/MiningUtils';
+import { Guis } from '../../utils/player/Inventory';
 import {
     ClientboundBlockUpdatePacket,
     ClientboundSectionBlocksUpdatePacket,
@@ -68,7 +69,7 @@ class PowderNuker extends ModuleBase {
         );
         manager.subscribe('emptydrill', () => {
             if (!this.enabled || this.refueling) return;
-            const refueling = (this.refueling = {});
+            const refueling = (this.refueling = { toolSlot: Player.getHeldItemIndex() });
             Client.stopMovement();
             Client.setKey('shift', false);
             Rotations.stop();
@@ -81,6 +82,7 @@ class PowderNuker extends ModuleBase {
                     if (!success) return this.stop('&cRefueling failed!');
                     this.message('&aRefueling successful!');
                     this.refueling = false;
+                    Guis.setItemSlot(refueling.toolSlot);
                     this.breaks.clear();
                     this.pendingBreaks.clear();
                     this.breakWindowStart = Date.now();


### PR DESCRIPTION
### Motivation
- Ensure the Powder Nuker restores the previously selected drill/pickaxe hotbar slot after a refuel so mining does not resume with the Abiphone selected.

### Description
- Import `Guis`, save the current held hotbar index into `refueling.toolSlot` when refueling begins, and call `Guis.setItemSlot(refueling.toolSlot)` after a successful refuel to restore the mining tool.

### Testing
- Ran `npx --yes prettier --write modules/mining/PowderNuker.js` and `git diff --check` as repository checks and both completed without errors, and no automated test suite is present per project guidelines.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9c57f507c4832c9f4594b810f61bee)